### PR TITLE
Reduce Windows CI test time by skipping some expensive platform independent tests

### DIFF
--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -272,6 +272,7 @@ class FilePathTest {
     @Issue("JENKINS-9540")
     @Test
     void errorMessageInRemoteCopyRecursive() throws Exception {
+        assumeFalse(Functions.isWindows() && System.getenv("CI") != null, "Expensive to run and not Windows specific");
         File src = newFolder(temp, "src");
         File dst = newFolder(temp, "dst");
             FilePath from = new FilePath(src);

--- a/core/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
+++ b/core/src/test/java/hudson/security/HudsonPrivateSecurityRealmTest.java
@@ -5,16 +5,19 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import hudson.Functions;
 import hudson.security.HudsonPrivateSecurityRealm.JBCryptEncoder;
 import hudson.security.HudsonPrivateSecurityRealm.PBKDF2PasswordEncoder;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.time.Duration;
 import javax.crypto.SecretKeyFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
@@ -25,6 +28,11 @@ class HudsonPrivateSecurityRealmTest {
     // MySecurePassword
     private static final String PBKDF2_HMAC_SHA512_ENCODED_PASSWORD =
             "$HMACSHA512:210000:30f9e0a5470a8bc67f128ca1aae25dd4$88abaca4f442caeff0096ec0f75df2d77cc31a956c564133232f4d2532a72c8d4380a718d5b2a3dccab9e752027eeadd8f9f2c0c624505531bf3a57ec7d08aad";
+
+    @BeforeEach
+    void skipTestsOnWindowsCI() {
+        assumeFalse(Functions.isWindows() && System.getenv("CI") != null, "Expensive to run and not Windows specific");
+    }
 
     /*
      * This exists so that we can easily check the complexity of how long this takes (ie is the number of iterations we

--- a/test/src/test/java/hudson/cli/Security3630Test.java
+++ b/test/src/test/java/hudson/cli/Security3630Test.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.jvnet.hudson.test.LoggerRule.recorded;
 
 import hudson.Functions;
@@ -80,6 +81,8 @@ public class Security3630Test {
 
     @Test
     void testConcurrentCliSessionPairing() throws InterruptedException, IOException {
+        assumeFalse(Functions.isWindows() && System.getenv("CI") != null, "Expensive to run and not Windows specific");
+
         // This test simulates the Jenkins CLI full-duplex HTTP protocol natively using CLI._main.
         // It concurrently establishes 'download' and 'upload' connections
         // to verify that the FullDuplexHttpService's session map handles concurrent put/get

--- a/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmFIPSTest.java
+++ b/test/src/test/java/hudson/security/HudsonPrivateSecurityRealmFIPSTest.java
@@ -30,7 +30,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+import hudson.Functions;
 import hudson.logging.LogRecorder;
 import hudson.logging.LogRecorderManager;
 import hudson.model.User;
@@ -45,6 +47,7 @@ import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.html.HtmlPasswordInput;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.jvnet.hudson.test.For;
@@ -64,6 +67,11 @@ class HudsonPrivateSecurityRealmFIPSTest {
     @RegisterExtension
     private final RealJenkinsExtension rjr = new RealJenkinsExtension().includeTestClasspathPlugins(false)
                                                        .javaOptions("-Xmx256M", "-Djenkins.security.FIPS140.COMPLIANCE=true");
+
+    @BeforeEach
+    void skipTestsOnWindowsCI() {
+        assumeFalse(Functions.isWindows() && System.getenv("CI") != null, "Expensive to run and not Windows specific");
+    }
 
     @Test
     void generalLogin() throws Throwable {

--- a/test/src/test/java/jenkins/agents/InboundAgentTlsTest.java
+++ b/test/src/test/java/jenkins/agents/InboundAgentTlsTest.java
@@ -1,5 +1,8 @@
 package jenkins.agents;
 
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+import hudson.Functions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -16,6 +19,7 @@ class InboundAgentTlsTest {
 
     @BeforeEach
     void setUp() throws Throwable {
+        assumeFalse(Functions.isWindows() && System.getenv("CI") != null, "Expensive to run and not Windows specific");
         rjr.startJenkins();
     }
 

--- a/test/src/test/java/jenkins/security/csp/WinstoneResponseHeaderLengthTest.java
+++ b/test/src/test/java/jenkins/security/csp/WinstoneResponseHeaderLengthTest.java
@@ -5,10 +5,13 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasLength;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+import hudson.Functions;
 import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.WebClient;
 import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.jvnet.hudson.test.junit.jupiter.RealJenkinsExtension;
@@ -17,6 +20,11 @@ public class WinstoneResponseHeaderLengthTest {
 
     @RegisterExtension
     public RealJenkinsExtension extension = new RealJenkinsExtension().addSyntheticPlugin(new RealJenkinsExtension.SyntheticPlugin(jenkins.security.csp.winstoneResponseHeaderLengthTest.ContributorImpl.class));
+
+    @BeforeEach
+    void skipTestsOnWindowsCI() {
+        assumeFalse(Functions.isWindows() && System.getenv("CI") != null, "Expensive to run and not Windows specific");
+    }
 
     @Test
     void testLength() throws Exception {

--- a/test/src/test/java/lib/form/PasswordTest.java
+++ b/test/src/test/java/lib/form/PasswordTest.java
@@ -34,11 +34,13 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.Functions;
 import hudson.Launcher;
 import hudson.cli.CopyJobCommand;
 import hudson.cli.GetJobCommand;
@@ -215,6 +217,7 @@ class PasswordTest {
     @Issue("SECURITY-3513")
     @Test
     void testCopyNodeSecrets() throws Exception {
+        assumeFalse(Functions.isWindows() && System.getenv("CI") != null, "Expensive to run and not Windows specific");
         Computer.EXTENDED_READ.setEnabled(true);
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         MockAuthorizationStrategy mockAuthorizationStrategy = new MockAuthorizationStrategy();
@@ -603,6 +606,7 @@ class PasswordTest {
 
     @Test
     void testBackgroundSecretConversion() throws Exception {
+        assumeFalse(Functions.isWindows() && System.getenv("CI") != null, "Expensive to run and not Windows specific");
         final JenkinsRule.WebClient wc = j.createWebClient();
         j.configRoundtrip();
         // empty default values
@@ -1044,6 +1048,7 @@ class PasswordTest {
 
     @Test
     void computerExtendedReadNoSecretsRevealed() throws Exception {
+        assumeFalse(Functions.isWindows() && System.getenv("CI") != null, "Expensive to run and not Windows specific");
         Computer computer = j.jenkins.getComputers()[0];
         computer.addAction(new SecuredAction());
 


### PR DESCRIPTION
## Reduce Windows CI test time by skipping some expensive platform independent tests

Tests on Windows CI require 5.5 hours to complete.  That's a lot of time to be paying for tests if they don't add significant value by running on Windows.  We're already running the same tests on Linux with Java 21 and Java 25.  Skip some of the longest running tests on Windows.

<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.

Fixes #<issue-number>
-->

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

* Confirmed that each test passes on Linux

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label skip-changelog

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
