### PR TITLE
Fix/redact auth header from logs

### DIFF
--- a/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
+++ b/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
@@ -127,6 +127,12 @@ public class BasicAuthenticationFilter implements CompatibleFilter {
             return;
         }
 
+        if (!authorization.regionMatches(true, 0, "Basic ", 0, 6)) {
+            // Not a Basic authentication header; let the container handle it
+            chain.doFilter(request, response);
+            return;
+        }
+
         // authenticate the user
         String username = null;
         String password = null;

--- a/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
+++ b/core/src/main/java/hudson/security/BasicAuthenticationFilter.java
@@ -134,7 +134,7 @@ public class BasicAuthenticationFilter implements CompatibleFilter {
         try {
             uidpassword = new String(Base64.getDecoder().decode(authorization.substring(6).getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
         } catch (IllegalArgumentException ex) {
-            LOGGER.log(Level.FINE, ex, () -> "Failed to decode authentication from: " + authorization);
+            LOGGER.log(Level.FINE, ex, () -> "Failed to decode Basic authentication header");
             uidpassword = "";
         }
         int idx = uidpassword.indexOf(':');

--- a/core/src/main/java/jenkins/security/BasicHeaderProcessor.java
+++ b/core/src/main/java/jenkins/security/BasicHeaderProcessor.java
@@ -74,7 +74,7 @@ public class BasicHeaderProcessor implements CompatibleFilter {
             try {
                 uidpassword = new String(Base64.getDecoder().decode(authorization.substring(6).getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
             } catch (IllegalArgumentException ex) {
-                LOGGER.log(Level.FINE, ex, () -> "Failed to decode authentication from: " + authorization);
+                LOGGER.log(Level.FINE, ex, () -> "Failed to decode Basic authentication header");
                 uidpassword = "";
             }
             int idx = uidpassword.indexOf(':');

--- a/core/src/test/java/hudson/security/BasicAuthenticationFilterTest.java
+++ b/core/src/test/java/hudson/security/BasicAuthenticationFilterTest.java
@@ -1,0 +1,200 @@
+package hudson.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+import jenkins.security.BasicApiTokenHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class BasicAuthenticationFilterTest {
+
+    private BasicAuthenticationFilter filter;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private FilterChain chain;
+    private ServletContext servletContext;
+    private MockedStatic<Jenkins> jenkinsMock;
+    private MockedStatic<BasicApiTokenHelper> tokenHelperMock;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        filter = new BasicAuthenticationFilter();
+
+        FilterConfig filterConfig = mock(FilterConfig.class);
+        servletContext = mock(ServletContext.class);
+        when(filterConfig.getServletContext()).thenReturn(servletContext);
+        filter.init(filterConfig);
+
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        chain = mock(FilterChain.class);
+
+        Jenkins jenkins = mock(Jenkins.class);
+        when(jenkins.isUseSecurity()).thenReturn(true);
+        jenkinsMock = mockStatic(Jenkins.class);
+        jenkinsMock.when(Jenkins::get).thenReturn(jenkins);
+
+        tokenHelperMock = mockStatic(BasicApiTokenHelper.class);
+        tokenHelperMock.when(() -> BasicApiTokenHelper.isConnectingUsingApiToken(any(), any())).thenReturn(null);
+
+        when(request.getUserPrincipal()).thenReturn(null);
+        when(request.getServletPath()).thenReturn("/api/json");
+    }
+
+    @AfterEach
+    void tearDown() {
+        tokenHelperMock.close();
+        jenkinsMock.close();
+    }
+
+    /**
+     * Non-Basic Authorization headers (e.g., Bearer, Digest) should be passed
+     * through the filter chain, not treated as malformed Basic auth.
+     */
+    @Test
+    void nonBasicAuthorizationHeaderIsPassedThrough() throws Exception {
+        when(request.getHeader("Authorization")).thenReturn("Bearer eyJhbGciOiJSUzI1NiJ9");
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(response, never()).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    /**
+     * A short Authorization header (fewer than 6 characters) must not cause
+     * a StringIndexOutOfBoundsException. It should be passed through since
+     * it cannot be a "Basic " header.
+     */
+    @Test
+    void shortAuthorizationHeaderDoesNotCrash() throws Exception {
+        when(request.getHeader("Authorization")).thenReturn("X");
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(response, never()).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    /**
+     * An empty Authorization header should be passed through without crashing.
+     */
+    @Test
+    void emptyAuthorizationHeaderDoesNotCrash() throws Exception {
+        when(request.getHeader("Authorization")).thenReturn("");
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(response, never()).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    /**
+     * A valid "Basic " prefix with invalid Base64 content should result in 401,
+     * and the log output must NOT contain the raw Authorization header value.
+     */
+    @Test
+    void malformedBase64ReturnsUnauthorizedWithoutLeakingCredentials() throws Exception {
+        when(request.getHeader("Authorization")).thenReturn("Basic not-valid-base64!!!");
+
+        Logger logger = Logger.getLogger(BasicAuthenticationFilter.class.getName());
+        Level originalLevel = logger.getLevel();
+        logger.setLevel(Level.FINE);
+        TestLogHandler logHandler = new TestLogHandler();
+        logger.addHandler(logHandler);
+
+        try {
+            filter.doFilter(request, response, chain);
+        } finally {
+            logger.removeHandler(logHandler);
+            logger.setLevel(originalLevel);
+        }
+
+        verify(response).setStatus(eq(HttpServletResponse.SC_UNAUTHORIZED));
+        verify(response).setHeader(eq("WWW-Authenticate"), eq("Basic realm=\"Jenkins user\""));
+        verify(chain, never()).doFilter(any(), any());
+
+        // Verify that a log record was emitted and that the raw Authorization header was NOT logged
+        assertFalse(logHandler.records.isEmpty(), "Expected at least one log record for decoding failure");
+        for (LogRecord record : logHandler.records) {
+            String message = record.getMessage();
+            if (record.getParameters() != null) {
+                message = java.text.MessageFormat.format(message, record.getParameters());
+            }
+            assertFalse(message.contains("not-valid-base64"),
+                    "Log message should not contain raw Authorization header value");
+        }
+    }
+
+    /**
+     * A valid Basic authorization header should extract username and password
+     * and proceed to authenticate rather than being bypassed or rejected.
+     */
+    @Test
+    void validBasicAuthorizationHeaderExtractsCredentials() throws Exception {
+        // "alice:secret" encoded in Base64 is "YWxpY2U6c2VjcmV0"
+        when(request.getHeader("Authorization")).thenReturn("Basic YWxpY2U6c2VjcmV0");
+        when(request.getContextPath()).thenReturn("");
+        when(request.getQueryString()).thenReturn(null);
+
+        RequestDispatcher dispatcher = mock(RequestDispatcher.class);
+        when(servletContext.getRequestDispatcher("/j_security_check?j_username=alice&j_password=secret")).thenReturn(dispatcher);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).setStatus(HttpServletResponse.SC_MOVED_TEMPORARILY);
+        verify(response).setHeader("Location", "/secured/api/json");
+        verify(dispatcher).include(request, response);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    /**
+     * Digest authorization should be passed through, not treated as Basic.
+     */
+    @Test
+    void digestAuthorizationHeaderIsPassedThrough() throws Exception {
+        when(request.getHeader("Authorization")).thenReturn("Digest username=\"admin\", realm=\"test\"");
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(response, never()).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    private static class TestLogHandler extends Handler {
+        final java.util.List<LogRecord> records = new java.util.ArrayList<>();
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/test/src/test/java/jenkins/security/BasicHeaderProcessorTest.java
+++ b/test/src/test/java/jenkins/security/BasicHeaderProcessorTest.java
@@ -1,7 +1,12 @@
 package jenkins.security;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.jvnet.hudson.test.LoggerRule.recorded;
 
 import hudson.ExtensionList;
 import hudson.model.UnprotectedRootAction;
@@ -11,6 +16,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.logging.Level;
 import jenkins.security.apitoken.ApiTokenPropertyConfiguration;
 import org.htmlunit.FailingHttpStatusCodeException;
 import org.htmlunit.Page;
@@ -19,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.kohsuke.stapler.HttpResponse;
@@ -144,6 +151,20 @@ class BasicHeaderProcessorTest {
             String authCode4 = encode(prefix, "foo:bar");
             makeRequestWithAuthCodeAndFail(authCode4);
             spySecurityListener.failedToAuthenticateCalls.assertLastEventIsAndThenRemoveIt("foo");
+        }
+    }
+
+    @Test
+    void malformedBase64HeaderDoesNotLeakCredentialsInLogs() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        wc = j.createWebClient();
+
+        LoggerRule logging = new LoggerRule().record(BasicHeaderProcessor.class, Level.FINE).capture(100);
+        try {
+            makeRequestWithAuthCodeAndFail("Basic secretpasswordnotvalidbase64!!!");
+        } finally {
+            assertThat(logging, recorded(Level.FINE, is("Failed to decode Basic authentication header")));
+            assertThat(logging, not(recorded(containsString("secretpasswordnotvalidbase64"))));
         }
     }
 


### PR DESCRIPTION
## Summary

Harden HTTP Basic authentication handling in Jenkins by preventing raw
`Authorization` headers from being written to FINE-level logs and by safely
handling malformed or non-Basic `Authorization` headers.

When Basic authentication decoding fails, the previous implementation included
the complete `Authorization` header in the log message. Since the header can
contain a Base64-encoded username and password, this could expose credentials
in Jenkins logs.

The legacy `BasicAuthenticationFilter` also attempted to process every
`Authorization` header as Basic authentication, even when the header used a
different authentication scheme or was shorter than the expected `Basic `
prefix. This could result in incorrect authentication handling and an
unhandled exception for short headers.

## Changes

* Stop logging the raw `Authorization` header when Basic authentication
  decoding fails in `BasicHeaderProcessor`.
* Stop logging the raw `Authorization` header when Basic authentication
  decoding fails in `BasicAuthenticationFilter`.
* Only process `Authorization` headers beginning with the `Basic ` scheme in
  `BasicAuthenticationFilter`.
* Pass non-Basic authentication schemes through the filter chain instead of
  attempting to decode them as Basic authentication.
* Prevent short or malformed `Authorization` headers from reaching unsafe
  substring handling.
* Preserve the existing valid Basic authentication flow.
* Add regression tests covering malformed headers, non-Basic schemes, valid
  Basic authentication, and log redaction.

## Testing done

The following targeted Jenkins test suites pass successfully:

* `mvn test -Dtest=BasicAuthenticationFilterTest -pl core -am`

  * Tests run: 6
  * Failures: 0
  * Errors: 0

* `mvn test -Dtest=BasicHeaderProcessorTest -pl test`

  * Tests run: 3
  * Failures: 0
  * Errors: 0

The tests verify that:

* raw `Authorization` header values are not written to authentication failure
  logs;
* short and empty headers do not cause an unhandled exception;
* non-Basic schemes such as Bearer and Digest are passed through;
* malformed Basic credentials return the expected authentication failure;
* valid Basic authentication continues to work as before.

## Scope

This change is intentionally limited to HTTP Basic authentication header
processing and its regression tests. No authentication APIs or valid Basic
authentication behavior are changed.

### Screenshots (UI changes only)

#### Before

#### After

### Proposed changelog entries

* Do not log raw authorization headers when Basic authentication fails
* Pass non-Basic authorization headers through the authentication filter

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A
