### PR TITLE
Use assert instead of assume in several tests

### DIFF
--- a/core/src/test/java/hudson/FilePathTest.java
+++ b/core/src/test/java/hudson/FilePathTest.java
@@ -430,7 +430,7 @@ class FilePathTest {
         final File tarFile = new File(tmpDir, filePrefix + ".tar");
 
         file.setLength(fileSize);
-        assumeTrue(fileSize == file.length());
+        assertEquals(fileSize, file.length(), "fileSize != file.length() for '" + filePrefix + "'");
         file.close();
 
         // Compress archive

--- a/test/src/test/java/hudson/model/SlaveTest.java
+++ b/test/src/test/java/hudson/model/SlaveTest.java
@@ -26,12 +26,12 @@ package hudson.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -185,7 +185,7 @@ class SlaveTest {
                 j.getInstance().getDescriptorByType(DumbSlave.DescriptorImpl.class);
         DescriptorExtensionList<ComputerLauncher, Descriptor<ComputerLauncher>> descriptors =
                 j.getInstance().getDescriptorList(ComputerLauncher.class);
-        assumeTrue(descriptors.size() > 1, "we need at least two launchers to test this");
+        assertThat("we need at least two launchers to test this", descriptors.size(), greaterThan(1));
         assertThat(descriptor.computerLauncherDescriptors(null), containsInAnyOrder(descriptors.toArray(new Descriptor[0])));
 
         Descriptor<ComputerLauncher> victim = descriptors.getFirst();
@@ -202,7 +202,7 @@ class SlaveTest {
         DumbSlave.DescriptorImpl descriptor =
                 j.getInstance().getDescriptorByType(DumbSlave.DescriptorImpl.class);
         DescriptorExtensionList<RetentionStrategy<?>, Descriptor<RetentionStrategy<?>>> descriptors = RetentionStrategy.all();
-        assumeTrue(descriptors.size() > 1, "we need at least two retention strategies to test this");
+        assertThat("we need at least two retention strategies to test this", descriptors.size(), greaterThan(1));
         assertThat(descriptor.retentionStrategyDescriptors(null), containsInAnyOrder(descriptors.toArray(new Descriptor[0])));
 
         Descriptor<RetentionStrategy<?>> victim = descriptors.getFirst();
@@ -220,7 +220,7 @@ class SlaveTest {
         DumbSlave.DescriptorImpl descriptor =
                 j.getInstance().getDescriptorByType(DumbSlave.DescriptorImpl.class);
         DescriptorExtensionList<NodeProperty<?>, NodePropertyDescriptor> descriptors = NodeProperty.all();
-        assumeTrue(descriptors.size() > 1, "we need at least two node properties to test this");
+        assertThat("we need at least two node properties to test this", descriptors.size(), greaterThan(1));
         assertThat(descriptor.nodePropertyDescriptors(null), containsInAnyOrder(descriptors.toArray(new Descriptor[0])));
 
         NodePropertyDescriptor victim = descriptors.getFirst();

--- a/test/src/test/java/hudson/model/UpdateCenterPluginInstallTest.java
+++ b/test/src/test/java/hudson/model/UpdateCenterPluginInstallTest.java
@@ -25,9 +25,8 @@
 package hudson.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -49,15 +48,11 @@ class UpdateCenterPluginInstallTest {
     private JenkinsRule jenkinsRule;
 
     @BeforeEach
-    void setUp(JenkinsRule rule) {
-        try {
-            jenkinsRule = rule;
-            jenkinsRule.jenkins.getUpdateCenter().getSite(UpdateCenter.ID_DEFAULT).updateDirectlyNow(false);
-        } catch (Exception x) {
-            assumeTrue(false, x.toString());
-        }
+    void setUp(JenkinsRule rule) throws Exception {
+        jenkinsRule = rule;
+        jenkinsRule.jenkins.getUpdateCenter().getSite(UpdateCenter.ID_DEFAULT).updateDirectlyNow(false);
         InetSocketAddress address = new InetSocketAddress("updates.jenkins-ci.org", 80);
-        assumeFalse(address.isUnresolved(), "Unable to resolve updates.jenkins-ci.org. Skip test.");
+        assertFalse(address.isUnresolved(), "Unable to resolve updates.jenkins-ci.org");
     }
 
     @Test

--- a/test/src/test/java/hudson/util/ArgumentListBuilder2Test.java
+++ b/test/src/test/java/hudson/util/ArgumentListBuilder2Test.java
@@ -150,7 +150,7 @@ class ArgumentListBuilder2Test {
         int code = p.join();
         listener.close();
 
-        assumeTrue(code == 0, "Failed to run " + args);
+        assertEquals(0, code, "Failed to run " + args);
         return out.toString(Charset.defaultCharset());
     }
 }

--- a/test/src/test/java/jenkins/security/ClassFilterImplTest.java
+++ b/test/src/test/java/jenkins/security/ClassFilterImplTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.LinkedListMultimap;
 import com.thoughtworks.xstream.XStream;
@@ -75,7 +75,7 @@ class ClassFilterImplTest {
 
     @Test
     void controllerToAgentBypassesWhitelist() throws Exception {
-        assumeTrue(ClassFilterImpl.WHITELISTED_CLASSES.stream().noneMatch(clazz -> clazz.equals(LinkedListMultimap.class.getName())));
+        assertTrue(ClassFilterImpl.WHITELISTED_CLASSES.stream().noneMatch(clazz -> clazz.equals(LinkedListMultimap.class.getName())));
         FreeStyleProject p = r.createFreeStyleProject();
         p.setAssignedNode(r.createSlave());
         p.getBuildersList().add(new M2SBuilder());
@@ -112,7 +112,7 @@ class ClassFilterImplTest {
 
     @Test
     void agentToControllerRequiresWhitelist() throws Exception {
-        assumeTrue(ClassFilterImpl.WHITELISTED_CLASSES.stream().noneMatch(clazz -> clazz.equals(LinkedListMultimap.class.getName())));
+        assertTrue(ClassFilterImpl.WHITELISTED_CLASSES.stream().noneMatch(clazz -> clazz.equals(LinkedListMultimap.class.getName())));
         FreeStyleProject p = r.createFreeStyleProject();
         p.setAssignedNode(r.createSlave());
         p.getBuildersList().add(new S2MBuilder());
@@ -145,7 +145,7 @@ class ClassFilterImplTest {
 
     @Test
     void xstreamRequiresWhitelist() throws Exception {
-        assumeTrue(ClassFilterImpl.WHITELISTED_CLASSES.stream().noneMatch(clazz -> clazz.equals(LinkedListMultimap.class.getName())));
+        assertTrue(ClassFilterImpl.WHITELISTED_CLASSES.stream().noneMatch(clazz -> clazz.equals(LinkedListMultimap.class.getName())));
         Config config = GlobalConfiguration.all().get(Config.class);
         config.save();
         config.obj = LinkedListMultimap.create();

--- a/test/src/test/java/jenkins/util/SystemPropertiesTest.java
+++ b/test/src/test/java/jenkins/util/SystemPropertiesTest.java
@@ -30,7 +30,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import jakarta.servlet.ServletContextEvent;
 import java.time.Duration;
@@ -127,7 +126,6 @@ class SystemPropertiesTest {
      * @param value value of the property
      */
     protected void setWebAppInitParameter(String property, String value) {
-        assumeTrue(j.jenkins.getServletContext() instanceof WebAppContext.Context);
         ((WebAppContext.Context) j.jenkins.getServletContext()).getContextHandler().getInitParams().put(property, value);
     }
 


### PR DESCRIPTION
## Use assert instead of assume in several tests

The JUnit assumptions API (assumeTrue, assumeFalse, etc.) cause a test to be skipped with an optional message that describes the reason the test is skipped when a condition is not satisfied.

These changes use assertions to cause the tests to fail if the condition is not satisfied.

Skipping a test when a condition is not satisfied is risky because it relies on people checking the message associated with the skipped test.  Assumptions that fail do not require action.  Assertions that fail require action because we will not merge a pull request with failing tests.

These changes are precursors to a future change from using the JUnit assumptions API to use the JUnit 6 EnableIF/DisableIf API.

<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.

Fixes #<issue-number>
-->

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

* Test as part of pull request:
  * https://github.com/jenkinsci/jenkins/pull/27251
* Tested on my Windows agents
* Tested on my Linux development machine

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label skip-changelog

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
