### PR TITLE
Fix scrollbar interaction at the right edge of page body

### DIFF
--- a/src/main/scss/base/_layout-commons.scss
+++ b/src/main/scss/base/_layout-commons.scss
@@ -4,7 +4,8 @@
   position: relative;
   display: grid;
   border: var(--jenkins-border);
-  margin-inline: var(--page-inset);
+  margin-inline-start: var(--page-inset);
+  margin-inline-end: 0;
   height: calc(100vh - var(--header-height) - var(--page-inset));
   border-radius: var(--form-input-border-radius);
   overflow: hidden;


### PR DESCRIPTION
## Description

The page body currently applies `var(--page-inset)` to both the left and right sides. Since `.app-page-body__contents` is independently scrollable, this leaves a small gap between the scrollbar and the right edge of the viewport.

This change removes the right-side page inset while preserving the left-side inset, allowing the scrollbar to extend to the right edge of the page.

## Changes

- Keep `var(--page-inset)` on the start/left side.
- Remove the end/right margin from `.app-page-body`.
- No other layout changes.

## Testing

- [ ] Not tested locally yet
- [ ] Jenkins tests
- [ ] Manual UI verification

Related to: #27244