### PR TITLE
Export ChannelTermination#cause when it is an ExportedBean

### DIFF
--- a/core/src/main/java/hudson/slaves/OfflineCause.java
+++ b/core/src/main/java/hudson/slaves/OfflineCause.java
@@ -118,6 +118,19 @@ public abstract class OfflineCause implements IOfflineCause {
             return cause.toString();
         }
 
+        /**
+         * Exposes {@link #cause} to the remote API, but only when its runtime type is itself
+         * annotated {@link ExportedBean}. Most exceptions are not, and attempting to export one
+         * of those throws {@code NotExportableException} and breaks the whole
+         * {@code computer/api/json} response for that agent.
+         *
+         * @since TODO
+         */
+        @Exported
+        public Exception getCause() {
+            return cause.getClass().isAnnotationPresent(ExportedBean.class) ? cause : null;
+        }
+
         @Override public String toString() {
             return Messages.OfflineCause_connection_was_broken_simple();
         }

--- a/core/src/test/java/hudson/slaves/OfflineCauseTest.java
+++ b/core/src/test/java/hudson/slaves/OfflineCauseTest.java
@@ -3,8 +3,11 @@ package hudson.slaves;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.junit.jupiter.api.Test;
+import org.kohsuke.stapler.export.ExportedBean;
 
 class OfflineCauseTest {
 
@@ -13,6 +16,31 @@ class OfflineCauseTest {
         String exceptionMessage = "exception message";
         OfflineCause.ChannelTermination cause = new OfflineCause.ChannelTermination(new RuntimeException(exceptionMessage));
         assertThat(cause.toString(), not(containsString(exceptionMessage)));
+    }
+
+    /**
+     * Most exceptions, like a plain {@link RuntimeException}, are not {@link ExportedBean}. Exporting
+     * one anyway throws {@code NotExportableException} and breaks the whole {@code computer/api/json}
+     * response for that agent, so {@link OfflineCause.ChannelTermination#getCause()} must not return it.
+     */
+    @Test
+    void testChannelTermination_getCause_notExportable() {
+        OfflineCause.ChannelTermination cause = new OfflineCause.ChannelTermination(new RuntimeException("boom"));
+        assertNull(cause.getCause());
+    }
+
+    @ExportedBean
+    private static class ExportableException extends Exception {
+        ExportableException(String message) {
+            super(message);
+        }
+    }
+
+    @Test
+    void testChannelTermination_getCause_exportable() {
+        ExportableException exportable = new ExportableException("boom");
+        OfflineCause.ChannelTermination cause = new OfflineCause.ChannelTermination(exportable);
+        assertSame(exportable, cause.getCause());
     }
 
 }


### PR DESCRIPTION
Fixes JENKINS-49217 / #22545.

Noticed a few people expressed interest on the issue over the last several months but nothing was ever opened, and @timja confirmed there's no assignment system (\"you're welcome to start working on this and open a pull request\"), so I picked it up.

## Problem

\`\`\`
computer/api/json?depth=1: NotExportableException: class java.io.IOException doesn't have @ExportedBean so cannot write hudson.slaves.OfflineCause$ChannelTermination.cause
\`\`\`

\`ChannelTermination.cause\` is a plain \`public final Exception\` field. Stapler's exporter requires the *runtime type* of anything it exports to be annotated \`@ExportedBean\`. Almost no built-in exception is, so the remote API call for an offline agent throws and the whole response breaks whenever the offline cause happens to be a channel termination.

## Fix

Per the issue title, only export \`cause\` when its runtime type actually is \`@ExportedBean\`:

\`\`\`java
@Exported
public Exception getCause() {
    return cause.getClass().isAnnotationPresent(ExportedBean.class) ? cause : null;
}
\`\`\`

In the (overwhelmingly common) case where it isn't, this returns \`null\` and the field is simply omitted from the JSON rather than throwing. This is the same shape of fix \`SimpleOfflineCause\` already uses a few lines above in this file — export something safe rather than the raw non-exportable object — just conditional instead of always exporting a String.

## Testing

Added \`OfflineCauseTest\`:
- \`testChannelTermination_getCause_notExportable\` — a plain \`RuntimeException\` → \`getCause()\` returns \`null\`.
- \`testChannelTermination_getCause_exportable\` — a test exception annotated \`@ExportedBean\` → \`getCause()\` returns it.

Ran \`mvn -pl core test -Dtest=OfflineCauseTest\` locally (JDK 21, Maven 3.9): 3 tests, 0 failures, including the pre-existing \`testChannelTermination_NoStacktrace\`. Also did a full \`mvn -pl core -am install -DskipTests\` to confirm the module and its dependents still build.

I did not run the full core test suite or start a Jenkins instance to hit the live \`computer/api/json\` endpoint, so it's worth double-checking the actual JSON output on a running instance with an agent whose channel really terminates.