### PR TITLE
Restore scrolling when selecting a section on the job configuration page in 2.577 & 2.578

### DIFF
--- a/src/main/js/section-to-sidebar-items.js
+++ b/src/main/js/section-to-sidebar-items.js
@@ -1,12 +1,14 @@
-import { createElementFromHtml, toId } from "./util/dom";
+import { createElementFromHtml, getScrollContainer, toId } from "./util/dom";
 
 const HEADER_SELECTOR =
   ".config-table .jenkins-app-bar h2, .config-table > .jenkins-section > .jenkins-section__title, .config-table > section > .jenkins-section > .jenkins-section__title";
 const DEFAULT_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M262.29 192.31a64 64 0 1057.4 57.4 64.13 64.13 0 00-57.4-57.4zM416.39 256a154.34 154.34 0 01-1.53 20.79l45.21 35.46a10.81 10.81 0 012.45 13.75l-42.77 74a10.81 10.81 0 01-13.14 4.59l-44.9-18.08a16.11 16.11 0 00-15.17 1.75A164.48 164.48 0 01325 400.8a15.94 15.94 0 00-8.82 12.14l-6.73 47.89a11.08 11.08 0 01-10.68 9.17h-85.54a11.11 11.11 0 01-10.69-8.87l-6.72-47.82a16.07 16.07 0 00-9-12.22 155.3 155.3 0 01-21.46-12.57 16 16 0 00-15.11-1.71l-44.89 18.07a10.81 10.81 0 01-13.14-4.58l-42.77-74a10.8 10.8 0 012.45-13.75l38.21-30a16.05 16.05 0 006-14.08c-.36-4.17-.58-8.33-.58-12.5s.21-8.27.58-12.35a16 16 0 00-6.07-13.94l-38.19-30A10.81 10.81 0 0149.48 186l42.77-74a10.81 10.81 0 0113.14-4.59l44.9 18.08a16.11 16.11 0 0015.17-1.75A164.48 164.48 0 01187 111.2a15.94 15.94 0 008.82-12.14l6.73-47.89A11.08 11.08 0 01213.23 42h85.54a11.11 11.11 0 0110.69 8.87l6.72 47.82a16.07 16.07 0 009 12.22 155.3 155.3 0 0121.46 12.57 16 16 0 0015.11 1.71l44.89-18.07a10.81 10.81 0 0113.14 4.58l42.77 74a10.8 10.8 0 01-2.45 13.75l-38.21 30a16.05 16.05 0 00-6.05 14.08c.33 4.14.55 8.3.55 12.47z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/></svg>`;
 
+let sectionHeaders = [];
+
 window.addEventListener("load", function () {
   const sidebarItems = document.querySelector("#tasks");
-  const sectionHeaders = document.querySelectorAll(HEADER_SELECTOR);
+  sectionHeaders = Array.from(document.querySelectorAll(HEADER_SELECTOR));
 
   // Create the sidebar items
   sectionHeaders.forEach(function (header, i) {
@@ -34,12 +36,19 @@ window.addEventListener("load", function () {
         item.querySelector(".task-link").dataset.sectionId,
       );
 
-      const sectionTopPosition =
-        headerToScrollTo.getBoundingClientRect().top + window.scrollY - 70;
-      window.scrollTo({
-        top: i === 0 ? 0 : sectionTopPosition,
-        behavior: "smooth",
-      });
+      if (!headerToScrollTo) {
+        return;
+      }
+
+      const container = getScrollContainer(headerToScrollTo);
+      const top =
+        i === 0
+          ? 0
+          : container.scrollTop +
+            topWithinContainer(headerToScrollTo, container) -
+            scrollPaddingTop(container);
+
+      container.scrollTo({ top, behavior: "smooth" });
     });
 
     sidebarItems.insertAdjacentElement("beforeend", item);
@@ -54,33 +63,63 @@ window.addEventListener("load", function () {
       input.parentElement.remove();
     });
 
-  document.addEventListener("scroll", () => onScroll());
+  // Scroll events don't bubble, so capture them to also catch nested containers
+  document.addEventListener(
+    "scroll",
+    (event) => {
+      if (event.target.contains(sectionHeaders[0])) {
+        onScroll();
+      }
+    },
+    true,
+  );
   onScroll();
 });
+
+// Distance between the top of the element and the top of the scrolling container
+function topWithinContainer(element, container) {
+  const top = element.getBoundingClientRect().top;
+
+  if (container === (document.scrollingElement || document.documentElement)) {
+    return top;
+  }
+
+  return top - container.getBoundingClientRect().top;
+}
+
+// scrollTo ignores scroll-padding, so read the offset back from the container
+function scrollPaddingTop(container) {
+  const padding = parseFloat(getComputedStyle(container).scrollPaddingTop);
+
+  return Number.isFinite(padding) ? padding : 0;
+}
 
 /**
  * Change the selected item depending on the user's vertical scroll position
  */
 function onScroll() {
-  const scrollY = Math.max(window.scrollY, 0);
-  const sectionHeaders = document.querySelectorAll(HEADER_SELECTOR);
+  if (sectionHeaders.length === 0) {
+    return;
+  }
 
-  let selectedSection = null;
+  const container = getScrollContainer(sectionHeaders[0]);
+  let selectedSection = sectionHeaders[0];
 
   // Calculate the top and height of each section to know when to switch selected sidebar item
   sectionHeaders.forEach(function (section, i) {
+    if (i === 0) {
+      return;
+    }
+
     const previousSection =
       i === 1
         ? document.querySelectorAll(".jenkins-section")[0]
-        : sectionHeaders[Math.max(i - 1, 0)].parentNode;
-    const viewportEntryOffset =
-      i === 0
-        ? 0
-        : section.parentNode.getBoundingClientRect().top +
-          window.scrollY -
-          previousSection.offsetHeight / 2;
+        : sectionHeaders[i - 1].parentNode;
+    const viewportEntryOffset = (previousSection?.offsetHeight ?? 0) / 2;
 
-    if (scrollY >= viewportEntryOffset) {
+    if (
+      topWithinContainer(section.parentNode, container) <= viewportEntryOffset
+    ) {
       selectedSection = section;
     }
   });
@@ -91,5 +130,5 @@ function onScroll() {
 
   document
     .querySelector(".task-link[data-section-id='" + selectedSection.id + "']")
-    .classList.add("task-link--active");
+    ?.classList.add("task-link--active");
 }

--- a/src/main/js/util/dom.js
+++ b/src/main/js/util/dom.js
@@ -10,3 +10,15 @@ export function toId(string) {
     .map((c) => c.codePointAt(0).toString(16))
     .join("-");
 }
+
+const SCROLLABLE_OVERFLOW = ["auto", "scroll", "overlay"];
+
+// The page body scrolls in a nested container rather than the document
+export function getScrollContainer(element) {
+  for (let node = element.parentElement; node; node = node.parentElement) {
+    if (SCROLLABLE_OVERFLOW.includes(getComputedStyle(node).overflowY)) {
+      return node;
+    }
+  }
+  return document.scrollingElement || document.documentElement;
+}

--- a/src/main/scss/base/_layout-commons.scss
+++ b/src/main/scss/base/_layout-commons.scss
@@ -8,6 +8,7 @@
   height: calc(100vh - var(--header-height) - var(--page-inset));
   border-radius: var(--form-input-border-radius);
   overflow: hidden;
+  scroll-padding-top: var(--section-padding);
 
   --top: color-mix(in oklch, white 1.5%, var(--card-background));
   --background: var(--card-background);
@@ -44,6 +45,7 @@
   & > .app-page-body__contents {
     padding: var(--section-padding);
     padding-bottom: 0;
+    scroll-padding-top: var(--section-padding);
   }
 
   @media (width >= 740px) {

--- a/src/test/js/section-to-sidebar-items.test.js
+++ b/src/test/js/section-to-sidebar-items.test.js
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The page body scrolls in a nested container rather than the document, so these
+ * tests assert which element is scrolled rather than how far the page moved.
+ * jsdom has no layout, so element rectangles are stubbed.
+ */
+const CONTAINER_TOP = 100;
+
+function render() {
+  document.body.innerHTML = `
+    <div id="tasks"></div>
+    <div id="page-body">
+      <div class="contents">
+        <div class="config-table">
+          <div class="jenkins-app-bar"><h2>General</h2></div>
+          <section class="jenkins-section">
+            <div class="jenkins-section__title">Triggers</div>
+          </section>
+          <section class="jenkins-section">
+            <div class="jenkins-section__title">Advanced</div>
+          </section>
+        </div>
+      </div>
+    </div>
+  `;
+
+  return document.querySelector(".contents");
+}
+
+function stubTop(element, top) {
+  element.getBoundingClientRect = () => ({
+    top,
+    bottom: top,
+    left: 0,
+    right: 0,
+    width: 0,
+    height: 0,
+    x: 0,
+    y: top,
+  });
+}
+
+function heading(text) {
+  return Array.from(
+    document.querySelectorAll(".jenkins-section__title, .jenkins-app-bar h2"),
+  ).find((element) => element.textContent.trim() === text);
+}
+
+function click(text) {
+  Array.from(document.querySelectorAll(".task-link"))
+    .find((button) => button.textContent.trim() === text)
+    .click();
+}
+
+function activeItem() {
+  const active = document.querySelector(".task-link--active");
+
+  return active ? active.textContent.trim() : null;
+}
+
+/**
+ * Loads the module, capturing the listeners it registers instead of letting them
+ * accumulate on the shared window and document between tests.
+ */
+async function load() {
+  const captured = {};
+  const onWindow = vi
+    .spyOn(window, "addEventListener")
+    .mockImplementation((type, handler) => {
+      if (type === "load") {
+        captured.load = handler;
+      }
+    });
+  const onDocument = vi
+    .spyOn(document, "addEventListener")
+    .mockImplementation((type, handler, options) => {
+      if (type === "scroll") {
+        captured.scroll = handler;
+        captured.scrollOptions = options;
+      }
+    });
+
+  vi.resetModules();
+  await import("../../main/js/section-to-sidebar-items.js");
+  captured.load();
+
+  onWindow.mockRestore();
+  onDocument.mockRestore();
+
+  return captured;
+}
+
+describe("section-to-sidebar-items", () => {
+  let contents;
+
+  beforeEach(() => {
+    contents = render();
+    contents.style.overflowY = "auto";
+    stubTop(contents, CONTAINER_TOP);
+    contents.scrollTo = vi.fn();
+    window.scrollTo = vi.fn();
+  });
+
+  it("builds a sidebar item for every section heading", async () => {
+    await load();
+
+    expect(
+      Array.from(document.querySelectorAll(".task-link-text")).map((item) =>
+        item.textContent.trim(),
+      ),
+    ).toEqual(["General", "Triggers", "Advanced"]);
+  });
+
+  it("scrolls the container the sections live in, never the window", async () => {
+    stubTop(heading("Triggers"), 400);
+    contents.scrollTop = 50;
+    await load();
+
+    click("Triggers");
+
+    // 50 already scrolled + (400 - 100) to the heading
+    expect(contents.scrollTo).toHaveBeenCalledWith({
+      top: 350,
+      behavior: "smooth",
+    });
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("subtracts the container's scroll-padding-top", async () => {
+    contents.style.scrollPaddingTop = "20px";
+    stubTop(heading("Triggers"), 400);
+    contents.scrollTop = 50;
+    await load();
+
+    click("Triggers");
+
+    expect(contents.scrollTo).toHaveBeenCalledWith({
+      top: 330,
+      behavior: "smooth",
+    });
+  });
+
+  it("returns to the top for the first item", async () => {
+    contents.scrollTop = 900;
+    await load();
+
+    click("General");
+
+    expect(contents.scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      behavior: "smooth",
+    });
+  });
+
+  it("falls back to the document when no ancestor scrolls", async () => {
+    contents.style.overflowY = "visible";
+    const scroller = document.scrollingElement || document.documentElement;
+    scroller.scrollTo = vi.fn();
+    scroller.scrollTop = 40;
+    stubTop(heading("Triggers"), 400);
+    await load();
+
+    click("Triggers");
+
+    expect(scroller.scrollTo).toHaveBeenCalledWith({
+      top: 440,
+      behavior: "smooth",
+    });
+    expect(contents.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("listens for scroll in the capture phase, as it does not bubble", async () => {
+    const captured = await load();
+
+    expect(captured.scrollOptions).toBe(true);
+  });
+
+  it("moves the selected item as the container scrolls", async () => {
+    stubTop(heading("Triggers").parentNode, 500);
+    stubTop(heading("Advanced").parentNode, 900);
+    const captured = await load();
+    expect(activeItem()).toBe("General");
+
+    // the container has scrolled, so Triggers is now above the fold
+    stubTop(heading("Triggers").parentNode, 50);
+    captured.scroll({ target: contents });
+
+    expect(activeItem()).toBe("Triggers");
+  });
+
+  it("ignores scrolling of elements the sections do not live in", async () => {
+    stubTop(heading("Triggers").parentNode, 500);
+    stubTop(heading("Advanced").parentNode, 900);
+    const captured = await load();
+    const unrelated = document.createElement("textarea");
+    document.body.appendChild(unrelated);
+
+    stubTop(heading("Triggers").parentNode, 50);
+    captured.scroll({ target: unrelated });
+
+    expect(activeItem()).toBe("General");
+  });
+});


### PR DESCRIPTION
Fixes #27269

Selecting any of the section links in the sidebar of a job's Configure page (General, Source Code Management, Triggers, Environment, Build Steps, Post-build Actions, and the pipeline equivalents) does nothing since 2.577. The page does not scroll, and the highlighted sidebar item stays stuck on the first section.

### Cause

Regression from #26863 (commit `e8809b04ee`), first released in 2.577.

The sidebar entries are buttons generated by `src/main/js/section-to-sidebar-items.js`, loaded from `core/src/main/resources/hudson/model/Job/configure.jelly`. The click handler scrolled the document:

```js
const sectionTopPosition =
  headerToScrollTo.getBoundingClientRect().top + window.scrollY - 70;
window.scrollTo({ top: i === 0 ? 0 : sectionTopPosition, behavior: "smooth" });
```

#26863 moved scrolling out of the document. `.app-page-body` became a fixed-height `overflow: hidden` grid, `.app-page-body__contents` took `overflow-y: auto`, and `.page-footer` became `display: none`. The document is now shorter than one viewport, so it has zero overflow: `window.scrollTo` is a no-op and `window.scrollY` is permanently 0. Measured on a real job Configure page, `document.scrollingElement.scrollHeight - clientHeight` is `0` while `.app-page-body__contents` has 3980px of scrollable height.

The same commit also deleted `html { scroll-padding-top: calc(var(--header-height) + var(--section-padding)) }` from `_core.scss` without adding an equivalent to the new scroll container.

Two related defects on the same page share the cause and are fixed here as well:

* The active sidebar item never updated, because `document.addEventListener("scroll", ...)` does not fire for a nested container (scroll events do not bubble to `document`) and the position maths read `window.scrollY`.
* `selectedSection` could be dereferenced while `null` when a page has no section headings.

### Changes

* `src/main/js/util/dom.js`: new `getScrollContainer(element)` helper that walks ancestors for a computed `overflow-y` of `auto`, `scroll` or `overlay`, falling back to `document.scrollingElement`.

* `src/main/js/section-to-sidebar-items.js`: the click handler resolves the scroll container and scrolls that one container explicitly, taking the offset from its computed `scroll-padding-top` so the value stays in CSS. The scroll spy listens in the capture phase so it also sees nested containers, filtered to the element that contains the sections so unrelated scrollers such as the pipeline script editor do not trigger it. The `-70` magic offset is removed.

  `scrollIntoView` is deliberately **not** used. It scrolls every scrollable ancestor, and `.app-page-body` remains programmatically scrollable even though `overflow: hidden` hides its scrollbar, so it also shifted the whole panel and carried the sidebar out of view with no way for the user to bring it back. Measured with `scrollIntoView`: `#page-body.scrollTop` went from 0 to 224 on a single click. With the explicit scroll it stays at 0.

* `src/main/scss/base/_layout-commons.scss`: `scroll-padding-top: var(--section-padding)` on `.app-page-body` and `.app-page-body__contents`, replacing the `html { scroll-padding-top }` that #26863 removed. This also improves where plain in-page anchors land inside that container.

* `src/test/js/section-to-sidebar-items.test.js`: eight vitest tests, see below.

### Relationship to #27265

#27265 proposes reverting #26863 in full. This change is deliberately written to be correct under both layouts, so it neither depends on nor blocks that revert. The container is resolved at click time and falls back to `document.scrollingElement`, and the offset comes from CSS `scroll-padding-top`, which the revert restores on `html` itself. If #27265 is merged, only the two SCSS lines added here become redundant. The `falls back to the document when no ancestor scrolls` test covers that path.

### A separate defect noticed while testing

On a normal job Configure page, `#page-body` has **1800px of hidden overflow**. A user cannot scroll it, but anything programmatic (focus, find-in-page, a plugin calling `scrollIntoView`) shifts the entire panel including the sidebar, with no way to scroll back. That is a layout defect from #26863, plausibly the same root cause as the double scrollbar reported in #27261. It is out of scope here and this change no longer triggers it.

### Testing done

**Automated.** `src/test/js/section-to-sidebar-items.test.js` adds eight tests on the vitest framework from #26595, which is now on master. Rebased onto it, `yarn test` reports 13 passing across both test files.

Six of the eight fail against the code before this change, which is the point of them:

| Test | Why it fails before this change |
| --- | --- |
| scrolls the container the sections live in, never the window | the container's `scrollTo` is called 0 times; `window.scrollTo` is called instead |
| subtracts the container's `scroll-padding-top` | same |
| returns to the top for the first item | same |
| falls back to the document when no ancestor scrolls | same |
| listens for scroll in the capture phase, as it does not bubble | the listener is registered without the capture argument, so `scrollOptions` is `undefined` |
| moves the selected item as the container scrolls | the spy never recomputes, since the event does not reach a listener on `document` |

jsdom has no layout engine, so the tests stub element rectangles and assert **which** element is scrolled and **with what offset**, rather than asserting real pixel positions. The browser measurements below cover what jsdom cannot.

**On a real development instance.** `mvn -pl war hpi:run` serving a freestyle job with parameters, a timer trigger, three build steps and an artifact archiver, driven over the Chrome DevTools Protocol so the before and after runs follow an identical scripted path on the same job and viewport.

| Clicked | `scrollTop` before this change | `scrollTop` after | Active sidebar item after |
| --- | --- | --- | --- |
| Environment | 0 (unchanged) | 2895 | Environment |
| Post-build Actions | 0 (unchanged) | 3980 | Post-build Actions |

Before the change the two captures for the two different anchors are byte-identical (md5 `368602a151b8eeaed5ce8e6840935f6e` for both): clicking produced no change in the rendered page at all.

**Across every branch of the current layout.** The compiled `styles.css` and `section-to-sidebar-items.js` from `yarn prod` were loaded into a DOM matching `layout.jelly` and driven the same way.

| Layout branch | Resolved scroller | `scrollTop` before this change | `scrollTop` after |
| --- | --- | --- | --- |
| Desktop, 1280px | `.app-page-body__contents` | 0 | 1940 |
| Narrow, 600px | `.app-page-body` | 0 | 2173 |
| Sidebar containing widgets | `.app-page-body` | 0 | 1941 |
| `data-disable-sticky="true"` | `HTML` | 1947 | 2017 |

The last row covers `hudson.Functions.disableStickyPositioning`, which acceptance tests use and which restores document scrolling. The old code only worked in that configuration; the new code works there too. It is also the configuration #27265 would make the default again.

Also checked in every case: clicking the first item returns to offset 0, scrolling upward from a later section works, and the active sidebar item tracks manual scrolling. Results were identical in Microsoft Edge, the browser in the issue report.

`yarn lint:css`, `eslint` and `prettier --check` all pass, and `yarn prod` builds.

### Screenshots (UI changes only)

There is no static visual difference; the difference is behavioural. Both images were captured on the same job at the same 1262x748 viewport, following an identical scripted path, clicking **Environment** in the sidebar.

#### Before

Clicked **Environment**. The form does not move and the sidebar highlight stays on General.

<img width="1262" height="748" alt="before-environment" src="https://github.com/user-attachments/assets/6d375c71-792b-4753-88e9-376253c0e871" />

#### After

Clicked **Environment**. The form scrolls to that section, the highlight moves to Environment, and the sidebar stays in place.

<img width="1262" height="748" alt="after-environment" src="https://github.com/user-attachments/assets/e64a70fc-5168-4d83-a226-6fff88312775" />

Comparing the captures pixel by pixel: the Before capture is within 3 pixels of the same page before any click at all, and the Before captures for two different anchors (Environment and Post-build Actions) are pixel-identical to each other. Clicking produced no change in the rendered page whatsoever. Before against After differs across 8.97% of the viewport.

### Proposed changelog entries

- Restore scrolling when selecting a section on the job configuration page.

### Proposed changelog category

/label regression-fix,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@janfaracik @MarkEWaite @timja @gbhat618

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.