### PR TITLE
 "Fix: Delete buttons wrongly hidden in nested f:repeatable (#27267)"

### DIFF
--- a/src/main/scss/form/_reorderable-list.scss
+++ b/src/main/scss/form/_reorderable-list.scss
@@ -233,77 +233,27 @@ div.repeated-chunk {
 
 /* ========================= repeatable elements ========================= */
 
-.repeated-chunk .show-if-last {
+.repeated-chunk > .jenkins-repeated-chunk__content .show-if-last {
   visibility: hidden;
 }
 
-.repeated-chunk.last .show-if-last {
+.repeated-chunk.last > .jenkins-repeated-chunk__content .show-if-last {
   visibility: visible;
 }
 
-.repeated-chunk .show-if-not-last {
+.repeated-chunk > .jenkins-repeated-chunk__content .show-if-not-last {
   visibility: visible;
 }
 
-.repeated-chunk.last .show-if-not-last {
+.repeated-chunk.last > .jenkins-repeated-chunk__content .show-if-not-last {
   visibility: hidden;
 }
 
-.repeated-chunk .show-if-not-only {
+.repeated-chunk > .jenkins-repeated-chunk__content .show-if-not-only {
   visibility: visible;
 }
 
-.repeated-chunk.first.last .show-if-not-only {
-  visibility: hidden;
-}
-
-/* == nested repeatable elements / 2 deep == */
-.repeated-chunk .repeated-chunk .show-if-last {
-  visibility: hidden;
-}
-
-.repeated-chunk .repeated-chunk.last .show-if-last {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk .show-if-not-last {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk.last .show-if-not-last {
-  visibility: hidden;
-}
-
-.repeated-chunk .repeated-chunk .show-if-not-only {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk.first.last .show-if-not-only {
-  visibility: hidden;
-}
-
-/* == nested repeatable elements / 3 deep == */
-.repeated-chunk .repeated-chunk .repeated-chunk .show-if-last {
-  visibility: hidden;
-}
-
-.repeated-chunk .repeated-chunk .repeated-chunk.last .show-if-last {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk .repeated-chunk .show-if-not-last {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk .repeated-chunk.last .show-if-not-last {
-  visibility: hidden;
-}
-
-.repeated-chunk .repeated-chunk .repeated-chunk .show-if-not-only {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk .repeated-chunk.first.last .show-if-not-only {
+.repeated-chunk.first.last > .jenkins-repeated-chunk__content .show-if-not-only {
   visibility: hidden;
 }
 


### PR DESCRIPTION
Fixes #27267 - Delete buttons wrongly hidden in nested f:repeatable when the outer list has a single entry.

**Root Cause:** CSS descendant selectors (`.repeated-chunk .show-if-not-only`) incorrectly matched buttons in nested repeatables. When outer list had 1 entry, its `.first.last` classes hid ALL inner delete buttons via specificity (0,4,0 vs 0,3,0).

**Fix:** Changed to child combinator targeting direct `.jenkins-repeated-chunk__content` child:
- `.repeated-chunk > .jenkins-repeated-chunk__content .show-if-*`
- Removed 2-deep/3-deep nested compensation rules (they couldn't express "closest ancestor" semantics)

**Verification:** SCSS compiles cleanly, generated CSS uses correct selectors.
