### PR TITLE
Fix: Delete buttons wrongly hidden in nested f:repeatable when outer list has single entry (#27267)

### DIFF
--- a/src/main/scss/form/_reorderable-list.scss
+++ b/src/main/scss/form/_reorderable-list.scss
@@ -233,77 +233,27 @@ div.repeated-chunk {
 
 /* ========================= repeatable elements ========================= */
 
-.repeated-chunk .show-if-last {
+.repeated-chunk > .jenkins-repeated-chunk__content .show-if-last {
   visibility: hidden;
 }
 
-.repeated-chunk.last .show-if-last {
+.repeated-chunk.last > .jenkins-repeated-chunk__content .show-if-last {
   visibility: visible;
 }
 
-.repeated-chunk .show-if-not-last {
+.repeated-chunk > .jenkins-repeated-chunk__content .show-if-not-last {
   visibility: visible;
 }
 
-.repeated-chunk.last .show-if-not-last {
+.repeated-chunk.last > .jenkins-repeated-chunk__content .show-if-not-last {
   visibility: hidden;
 }
 
-.repeated-chunk .show-if-not-only {
+.repeated-chunk > .jenkins-repeated-chunk__content .show-if-not-only {
   visibility: visible;
 }
 
-.repeated-chunk.first.last .show-if-not-only {
-  visibility: hidden;
-}
-
-/* == nested repeatable elements / 2 deep == */
-.repeated-chunk .repeated-chunk .show-if-last {
-  visibility: hidden;
-}
-
-.repeated-chunk .repeated-chunk.last .show-if-last {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk .show-if-not-last {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk.last .show-if-not-last {
-  visibility: hidden;
-}
-
-.repeated-chunk .repeated-chunk .show-if-not-only {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk.first.last .show-if-not-only {
-  visibility: hidden;
-}
-
-/* == nested repeatable elements / 3 deep == */
-.repeated-chunk .repeated-chunk .repeated-chunk .show-if-last {
-  visibility: hidden;
-}
-
-.repeated-chunk .repeated-chunk .repeated-chunk.last .show-if-last {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk .repeated-chunk .show-if-not-last {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk .repeated-chunk.last .show-if-not-last {
-  visibility: hidden;
-}
-
-.repeated-chunk .repeated-chunk .repeated-chunk .show-if-not-only {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk .repeated-chunk.first.last .show-if-not-only {
+.repeated-chunk.first.last > .jenkins-repeated-chunk__content .show-if-not-only {
   visibility: hidden;
 }
 


### PR DESCRIPTION
Fixes #27267

### Testing done
SCSS compiles cleanly. Verified generated CSS uses correct child combinator selectors (`.repeated-chunk > .jenkins-repeated-chunk__content .show-if-*`). Removed buggy 2-deep/3-deep nested descendant selector rules that incorrectly hid inner delete buttons when outer list had single entry.

### Screenshots (UI changes only)

#### Before
Inner delete buttons hidden (visibility: hidden) when outer repeatable has 1 entry

#### After
Inner delete buttons visible when inner list has multiple entries

### Proposed changelog entries
- Fix delete buttons incorrectly hidden in nested f:repeatable when outer list has single entry

### Proposed changelog category
/label bug

### Proposed upgrade guidelines
N/A

### Submitter checklist
- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin.
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers
@jenkinsci/core-pr-reviewers