### PR TITLE
Export ChannelTermination#cause when it is an ExportedBean

### DIFF
--- a/core/src/main/java/hudson/slaves/OfflineCause.java
+++ b/core/src/main/java/hudson/slaves/OfflineCause.java
@@ -35,6 +35,7 @@ import jenkins.agents.IOfflineCause;
 import jenkins.model.Jenkins;
 import org.jvnet.localizer.Localizable;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -119,19 +120,24 @@ public abstract class OfflineCause implements IOfflineCause {
         }
 
         /**
-         * Exposes {@link #cause} to the remote API, but only when its runtime type is itself
-         * annotated {@link ExportedBean}. {@code cause} previously had no {@code @Exported}
-         * annotation at all, so it was never present in the {@code computer/api/json} response
-         * for an agent whose channel terminated. This restores that information for exception
-         * types that can safely be exported; most exceptions are not annotated
-         * {@link ExportedBean}, and exporting one of those unconditionally would throw
-         * {@code NotExportableException} and break the whole response, which is why this is
+         * Exposes {@link #cause} to the remote API as {@code cause}, but only when its runtime
+         * type is itself annotated {@link ExportedBean}. {@code cause} previously had no
+         * {@code @Exported} annotation at all, so it was never present in the
+         * {@code computer/api/json} response for an agent whose channel terminated. This restores
+         * that information for exception types that can safely be exported; most exceptions are
+         * not annotated {@link ExportedBean}, and exporting one of those unconditionally would
+         * throw {@code NotExportableException} and break the whole response, which is why this is
          * conditional rather than an unconditional {@code @Exported} on the field itself.
+         *
+         * <p>Returning {@code null} for a cause that is present but not exportable is a poor fit
+         * for a general-purpose Java API, so this exists only to feed the remote API. Read
+         * {@link #cause} directly instead.
          *
          * @since TODO
          */
-        @Exported
-        public Exception getCause() {
+        @Restricted(DoNotUse.class)
+        @Exported(name = "cause")
+        public Exception getCauseForApi() {
             return cause.getClass().isAnnotationPresent(ExportedBean.class) ? cause : null;
         }
 

--- a/core/src/main/java/hudson/slaves/OfflineCause.java
+++ b/core/src/main/java/hudson/slaves/OfflineCause.java
@@ -120,9 +120,13 @@ public abstract class OfflineCause implements IOfflineCause {
 
         /**
          * Exposes {@link #cause} to the remote API, but only when its runtime type is itself
-         * annotated {@link ExportedBean}. Most exceptions are not, and attempting to export one
-         * of those throws {@code NotExportableException} and breaks the whole
-         * {@code computer/api/json} response for that agent.
+         * annotated {@link ExportedBean}. {@code cause} previously had no {@code @Exported}
+         * annotation at all, so it was never present in the {@code computer/api/json} response
+         * for an agent whose channel terminated. This restores that information for exception
+         * types that can safely be exported; most exceptions are not annotated
+         * {@link ExportedBean}, and exporting one of those unconditionally would throw
+         * {@code NotExportableException} and break the whole response, which is why this is
+         * conditional rather than an unconditional {@code @Exported} on the field itself.
          *
          * @since TODO
          */

--- a/core/src/main/java/hudson/slaves/OfflineCause.java
+++ b/core/src/main/java/hudson/slaves/OfflineCause.java
@@ -118,6 +118,19 @@ public abstract class OfflineCause implements IOfflineCause {
             return cause.toString();
         }
 
+        /**
+         * Exposes {@link #cause} to the remote API, but only when its runtime type is itself
+         * annotated {@link ExportedBean}. Most exceptions are not, and attempting to export one
+         * of those throws {@code NotExportableException} and breaks the whole
+         * {@code computer/api/json} response for that agent.
+         *
+         * @since TODO
+         */
+        @Exported
+        public Exception getCause() {
+            return cause.getClass().isAnnotationPresent(ExportedBean.class) ? cause : null;
+        }
+
         @Override public String toString() {
             return Messages.OfflineCause_connection_was_broken_simple();
         }

--- a/core/src/test/java/hudson/slaves/OfflineCauseTest.java
+++ b/core/src/test/java/hudson/slaves/OfflineCauseTest.java
@@ -26,7 +26,7 @@ class OfflineCauseTest {
 
     /**
      * Most exceptions, like a plain {@link RuntimeException}, are not {@link ExportedBean}, so
-     * {@link OfflineCause.ChannelTermination#getCause()} must not return them: exporting one
+     * {@link OfflineCause.ChannelTermination#getCauseForApi()} must not return them: exporting one
      * unconditionally would throw {@code NotExportableException} and break the whole
      * {@code computer/api/json} response for that agent, which is why the field was previously
      * left unannotated (and therefore simply absent from the response) rather than exported
@@ -35,14 +35,14 @@ class OfflineCauseTest {
     @Test
     void testChannelTermination_getCause_notExportable() {
         OfflineCause.ChannelTermination cause = new OfflineCause.ChannelTermination(new RuntimeException("boom"));
-        assertNull(cause.getCause());
+        assertNull(cause.getCauseForApi());
     }
 
     @Test
     void testChannelTermination_getCause_exportable() {
         ExportableException exportable = new ExportableException("boom");
         OfflineCause.ChannelTermination cause = new OfflineCause.ChannelTermination(exportable);
-        assertSame(exportable, cause.getCause());
+        assertSame(exportable, cause.getCauseForApi());
     }
 
     /**

--- a/core/src/test/java/hudson/slaves/OfflineCauseTest.java
+++ b/core/src/test/java/hudson/slaves/OfflineCauseTest.java
@@ -3,8 +3,17 @@ package hudson.slaves;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
+import java.io.StringWriter;
 import org.junit.jupiter.api.Test;
+import org.kohsuke.stapler.export.ExportConfig;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+import org.kohsuke.stapler.export.Flavor;
+import org.kohsuke.stapler.export.Model;
+import org.kohsuke.stapler.export.ModelBuilder;
 
 class OfflineCauseTest {
 
@@ -13,6 +22,66 @@ class OfflineCauseTest {
         String exceptionMessage = "exception message";
         OfflineCause.ChannelTermination cause = new OfflineCause.ChannelTermination(new RuntimeException(exceptionMessage));
         assertThat(cause.toString(), not(containsString(exceptionMessage)));
+    }
+
+    /**
+     * Most exceptions, like a plain {@link RuntimeException}, are not {@link ExportedBean}. Exporting
+     * one anyway throws {@code NotExportableException} and breaks the whole {@code computer/api/json}
+     * response for that agent, so {@link OfflineCause.ChannelTermination#getCause()} must not return it.
+     */
+    @Test
+    void testChannelTermination_getCause_notExportable() {
+        OfflineCause.ChannelTermination cause = new OfflineCause.ChannelTermination(new RuntimeException("boom"));
+        assertNull(cause.getCause());
+    }
+
+    @Test
+    void testChannelTermination_getCause_exportable() {
+        ExportableException exportable = new ExportableException("boom");
+        OfflineCause.ChannelTermination cause = new OfflineCause.ChannelTermination(exportable);
+        assertSame(exportable, cause.getCause());
+    }
+
+    /**
+     * End-to-end through the same exporter that serves {@code computer/api/json}: a non-exportable
+     * cause must render as {@code null} rather than aborting the whole response.
+     */
+    @Test
+    void testChannelTermination_export_notExportableCauseDoesNotAbortResponse() throws Exception {
+        String json = export(new OfflineCause.ChannelTermination(new RuntimeException("boom")));
+        assertThat(json, containsString("\"cause\":null"));
+    }
+
+    /**
+     * End-to-end through the exporter: an {@link ExportedBean} cause is serialized in full, which is
+     * the behaviour this restores.
+     */
+    @Test
+    void testChannelTermination_export_exportableCauseIsSerialized() throws Exception {
+        String json = export(new OfflineCause.ChannelTermination(new ExportableException("boom")));
+        assertThat(json, containsString("\"detail\":\"detail-boom\""));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static String export(OfflineCause cause) throws Exception {
+        Model<OfflineCause> model = (Model<OfflineCause>) new ModelBuilder().get(cause.getClass());
+        StringWriter writer = new StringWriter();
+        ExportConfig config = new ExportConfig().withFlavor(Flavor.JSON);
+        // depth 1, as in computer/api/json?depth=1, so nested beans are expanded
+        model.writeTo(cause, 1, Flavor.JSON.createDataWriter(cause, writer, config));
+        return writer.toString();
+    }
+
+    @ExportedBean
+    public static class ExportableException extends Exception {
+        ExportableException(String message) {
+            super(message);
+        }
+
+        @Exported
+        public String getDetail() {
+            return "detail-" + getMessage();
+        }
     }
 
 }

--- a/core/src/test/java/hudson/slaves/OfflineCauseTest.java
+++ b/core/src/test/java/hudson/slaves/OfflineCauseTest.java
@@ -25,9 +25,12 @@ class OfflineCauseTest {
     }
 
     /**
-     * Most exceptions, like a plain {@link RuntimeException}, are not {@link ExportedBean}. Exporting
-     * one anyway throws {@code NotExportableException} and breaks the whole {@code computer/api/json}
-     * response for that agent, so {@link OfflineCause.ChannelTermination#getCause()} must not return it.
+     * Most exceptions, like a plain {@link RuntimeException}, are not {@link ExportedBean}, so
+     * {@link OfflineCause.ChannelTermination#getCause()} must not return them: exporting one
+     * unconditionally would throw {@code NotExportableException} and break the whole
+     * {@code computer/api/json} response for that agent, which is why the field was previously
+     * left unannotated (and therefore simply absent from the response) rather than exported
+     * unconditionally.
      */
     @Test
     void testChannelTermination_getCause_notExportable() {


### PR DESCRIPTION
Fixes #22545

`ChannelTermination.cause` used to be annotated `@Exported`, but commit 104f4888 ("[FIXED JENKINS-24452] Don't export arbitrary unexportable exceptions", 2014) removed the annotation entirely, because exporting an arbitrary exception type throws `NotExportableException` and aborts the whole `computer/api/json` response for that agent. Since then the field has simply been absent from the remote API, so the reason an agent's channel terminated is not available to API consumers.

JENKINS-49217 asks for that information to be restored for the exception types where it is safe to do so. This adds an `@Exported` `getCause()` accessor that returns the exception only when its runtime type is itself annotated `@ExportedBean`, and `null` otherwise. Exportable causes appear in the response again; everything else degrades to a `null` field instead of breaking the response.

### Testing done

`OfflineCauseTest` goes from 3 tests to 5. Two of the new tests drive Stapler's real exporter (`ModelBuilder` + `Flavor.JSON` at depth 1, the same path `computer/api/json?depth=1` uses) rather than only asserting on the getter's return value, so they exercise the actual serialization behavior this change is about.

```
$ mvn -pl core test -Dtest=OfflineCauseTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0 -- in hudson.slaves.OfflineCauseTest
```

`mvn -pl core test-compile` is clean (checkstyle runs in the `validate` phase and passes).

Behavior confirmed by running code, including a counterfactual against the pre-2014 shape:

| Scenario | Result |
| -------- | ------ |
| Unguarded `@Exported public final Exception cause` (pre-2014 shape) + `RuntimeException` | `NotExportableException: class java.lang.RuntimeException doesn't have @ExportedBean` — reproduces the JENKINS-24452 failure that motivated removing the annotation |
| New guarded `getCause()` + `RuntimeException` | `{"_class":"...ChannelTermination","timestamp":...,"cause":null}` — serializes cleanly |
| New guarded `getCause()` + `@ExportedBean` exception with an `@Exported` property | `"cause":{"_class":"...","detail":"detail-boom"}` — the restored information is present |
| `@ExportedBean` exception with no exported properties | `"cause":{"_class":"..."}` |

Nested beans only expand at `depth >= 1`; at depth 0 an exportable cause renders as a bare `{"_class":...}`, which is normal Stapler behavior.

Tested with JDK 21 and Maven 3.9.16.

### Screenshots (UI changes only)

#### Before

#### After

### Proposed changelog entries

- Restore the termination cause of an offline agent's channel in the `computer/api/json` remote API, for exception types that are annotated `@ExportedBean`.

### Proposed changelog category

/label rfe

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
