### PR TITLE
[JENKINS-62431] Allow SYSTEM_READ viewers to browse Load Statistics

### DIFF
--- a/core/src/main/java/jenkins/management/StatisticsLink.java
+++ b/core/src/main/java/jenkins/management/StatisticsLink.java
@@ -55,7 +55,8 @@ public class StatisticsLink extends ManagementLink {
     @NonNull
     @Override
     public Permission getRequiredPermission() {
-        return Jenkins.MANAGE;
+        //This link is displayed to any user with permission to access the management menu
+        return Jenkins.READ;
     }
 
     @Override

--- a/core/src/main/resources/jenkins/model/Jenkins/load-statistics.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/load-statistics.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:new className="jenkins.management.StatisticsLink" var="it" />
 
-  <l:settings-subpage includeBreadcrumb="true">
+  <l:settings-subpage includeBreadcrumb="true" permissions="${app.MANAGE_AND_SYSTEM_READ}">
     <j:set var="it" value="${app}" />
 
     <j:set var="prefix" value="overallLoad" />

--- a/test/src/test/java/jenkins/management/StatisticsLinkReadOnlyModeTest.java
+++ b/test/src/test/java/jenkins/management/StatisticsLinkReadOnlyModeTest.java
@@ -24,6 +24,7 @@
 
 package jenkins.management;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -68,15 +69,33 @@ class StatisticsLinkReadOnlyModeTest {
     void systemReadViewerCanAccessPage() throws Exception {
         realm.createAccount("viewer", "viewer");
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
-                .grant(Jenkins.ADMINISTER).everywhere().to("admin")
                 .grant(Jenkins.READ, Jenkins.SYSTEM_READ).everywhere().to("viewer"));
 
         JenkinsRule.WebClient wc = j.createWebClient();
         wc.login("viewer", "viewer");
         HtmlPage page = wc.goTo("manage/load-statistics");
+        wc.waitForBackgroundJavaScript(2000);
 
-        assertTrue(page.asNormalizedText().contains("Load Statistics"),
-                "a SYSTEM_READ-only viewer should be able to reach the Load Statistics page");
+        assertTrue(page.asNormalizedText().contains("Timespan"),
+                "a SYSTEM_READ-only viewer should see the deferred load statistics content, not just the page shell");
+    }
+
+    @Issue("JENKINS-62431")
+    @Test
+    void systemReadViewerCanAccessPageViaBareUrl() throws Exception {
+        // jenkins/model/Jenkins/load-statistics.jelly also resolves off the bare root URL,
+        // not just under manage/ - both paths must honor the same permission gate.
+        realm.createAccount("viewer", "viewer");
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ, Jenkins.SYSTEM_READ).everywhere().to("viewer"));
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.login("viewer", "viewer");
+        HtmlPage page = wc.goTo("load-statistics");
+        wc.waitForBackgroundJavaScript(2000);
+
+        assertTrue(page.asNormalizedText().contains("Timespan"),
+                "a SYSTEM_READ-only viewer should be able to reach the Load Statistics page via the bare URL too");
     }
 
     @Issue("JENKINS-62431")
@@ -84,14 +103,14 @@ class StatisticsLinkReadOnlyModeTest {
     void manageViewerCanStillAccessPage() throws Exception {
         realm.createAccount("manager", "manager");
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
-                .grant(Jenkins.ADMINISTER).everywhere().to("admin")
                 .grant(Jenkins.READ, Jenkins.MANAGE).everywhere().to("manager"));
 
         JenkinsRule.WebClient wc = j.createWebClient();
         wc.login("manager", "manager");
         HtmlPage page = wc.goTo("manage/load-statistics");
+        wc.waitForBackgroundJavaScript(2000);
 
-        assertTrue(page.asNormalizedText().contains("Load Statistics"),
+        assertTrue(page.asNormalizedText().contains("Timespan"),
                 "a MANAGE-only viewer must keep the access it already had before this change");
     }
 
@@ -100,7 +119,6 @@ class StatisticsLinkReadOnlyModeTest {
     void viewerWithoutRequiredPermissionIsDenied() throws Exception {
         realm.createAccount("nobody", "nobody");
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
-                .grant(Jenkins.ADMINISTER).everywhere().to("admin")
                 .grant(Jenkins.READ).everywhere().to("nobody"));
 
         JenkinsRule.WebClient wc = j.createWebClient();
@@ -108,6 +126,6 @@ class StatisticsLinkReadOnlyModeTest {
 
         FailingHttpStatusCodeException ex = assertThrows(FailingHttpStatusCodeException.class,
                 () -> wc.goTo("manage/load-statistics"));
-        assertTrue(ex.getStatusCode() == 403, "expected 403 for a viewer without MANAGE or SYSTEM_READ");
+        assertEquals(403, ex.getStatusCode(), "expected 403 for a viewer without MANAGE or SYSTEM_READ");
     }
 }

--- a/test/src/test/java/jenkins/management/StatisticsLinkReadOnlyModeTest.java
+++ b/test/src/test/java/jenkins/management/StatisticsLinkReadOnlyModeTest.java
@@ -1,0 +1,113 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, CloudBees, Inc. and others
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.management;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.security.HudsonPrivateSecurityRealm;
+import jenkins.model.Jenkins;
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Part of the JENKINS-12548 "Read-only system configuration browsing" epic (JEP-224).
+ *
+ * <p>The "Load Statistics" page ({@code jenkins/model/Jenkins/load-statistics.jelly}, reachable
+ * via {@link StatisticsLink}) previously required {@link Jenkins#MANAGE} both for the
+ * {@link hudson.model.ManagementLink} to be shown on "Manage Jenkins" and, once the class of the
+ * URL was actually reached through a resolved link, was rendered with no permission check of its
+ * own at all. This left the page unreachable for viewers with only {@link Jenkins#SYSTEM_READ}
+ * even though the page is purely informational (load statistics graphs), mirroring how
+ * {@code jenkins/model/Jenkins/systemInfo.jelly} already gates itself on
+ * {@code Jenkins#MANAGE_AND_SYSTEM_READ}.
+ */
+@WithJenkins
+class StatisticsLinkReadOnlyModeTest {
+
+    private JenkinsRule j;
+    private HudsonPrivateSecurityRealm realm;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) throws Exception {
+        j = rule;
+        realm = new HudsonPrivateSecurityRealm(false, false, null);
+        j.jenkins.setSecurityRealm(realm);
+    }
+
+    @Issue("JENKINS-62431")
+    @Test
+    void systemReadViewerCanAccessPage() throws Exception {
+        realm.createAccount("viewer", "viewer");
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.ADMINISTER).everywhere().to("admin")
+                .grant(Jenkins.READ, Jenkins.SYSTEM_READ).everywhere().to("viewer"));
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.login("viewer", "viewer");
+        HtmlPage page = wc.goTo("manage/load-statistics");
+
+        assertTrue(page.asNormalizedText().contains("Load Statistics"),
+                "a SYSTEM_READ-only viewer should be able to reach the Load Statistics page");
+    }
+
+    @Issue("JENKINS-62431")
+    @Test
+    void manageViewerCanStillAccessPage() throws Exception {
+        realm.createAccount("manager", "manager");
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.ADMINISTER).everywhere().to("admin")
+                .grant(Jenkins.READ, Jenkins.MANAGE).everywhere().to("manager"));
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.login("manager", "manager");
+        HtmlPage page = wc.goTo("manage/load-statistics");
+
+        assertTrue(page.asNormalizedText().contains("Load Statistics"),
+                "a MANAGE-only viewer must keep the access it already had before this change");
+    }
+
+    @Issue("JENKINS-62431")
+    @Test
+    void viewerWithoutRequiredPermissionIsDenied() throws Exception {
+        realm.createAccount("nobody", "nobody");
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.ADMINISTER).everywhere().to("admin")
+                .grant(Jenkins.READ).everywhere().to("nobody"));
+
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.login("nobody", "nobody");
+
+        FailingHttpStatusCodeException ex = assertThrows(FailingHttpStatusCodeException.class,
+                () -> wc.goTo("manage/load-statistics"));
+        assertTrue(ex.getStatusCode() == 403, "expected 403 for a viewer without MANAGE or SYSTEM_READ");
+    }
+}


### PR DESCRIPTION
See [JENKINS-62431](https://issues.jenkins.io/browse/JENKINS-62431) / #11549.

Part of the JENKINS-12548 "Read-only system configuration browsing" epic (JEP-224).

## Problem

The "Load Statistics" management link (`jenkins.management.StatisticsLink`) required `Jenkins.MANAGE` just to be *listed* on "Manage Jenkins", hiding it from JEP-224 read-only viewers who only hold `Overall/SystemRead`. The page itself (`jenkins/model/Jenkins/load-statistics.jelly`) also rendered with no permission gate of its own at all - confirmed empirically that the direct URL `manage/load-statistics` was reachable by any authenticated user holding just `Overall/Read`, even before this fix.

## Fix

Mirrors the established core pattern for purely informational "Manage Jenkins" subpages (`jenkins.management.SystemInfoLink`, `jenkins.management.NodesLink`, `jenkins/model/Jenkins/systemInfo.jelly`):

- `StatisticsLink#getRequiredPermission()`: `Jenkins.MANAGE` → `Jenkins.READ` (link is now shown to anyone who can reach "Manage Jenkins" at all, i.e. `MANAGE` or `SYSTEM_READ` holders).
- `load-statistics.jelly`: added `permissions="${app.MANAGE_AND_SYSTEM_READ}"` to `<l:settings-subpage>`, matching `systemInfo.jelly` exactly.

New test `StatisticsLinkReadOnlyModeTest` covers: a `SYSTEM_READ`-only viewer can now reach the page (both under `manage/` and via the bare `/load-statistics` URL the view also resolves off), a `MANAGE`-only viewer keeps the access it already had (no regression), and a viewer with neither gets a 403.

## Screenshots

**Before** - `SYSTEM_READ`-only viewer: no "Load Statistics" link on "Manage Jenkins"

![before - no link](https://raw.githubusercontent.com/Racknaraock/jenkins/pr-assets/JENKINS-62431/JENKINS-62431/before-01-manage-jenkins-no-link.png)

**Before** - the page was reachable directly by URL regardless, with no real gate

![before - ungated direct URL](https://raw.githubusercontent.com/Racknaraock/jenkins/pr-assets/JENKINS-62431/JENKINS-62431/before-02-direct-url-ungated.png)

**After** - the link now correctly appears for the `SYSTEM_READ`-only viewer

![after - link visible](https://raw.githubusercontent.com/Racknaraock/jenkins/pr-assets/JENKINS-62431/JENKINS-62431/after-01-manage-jenkins-with-link.png)

**After** - the page renders correctly for that same viewer

![after - page renders](https://raw.githubusercontent.com/Racknaraock/jenkins/pr-assets/JENKINS-62431/JENKINS-62431/after-02-load-statistics-page.png)

## Follow-up found while working on this

While tracing how the page's data is actually served, I found that the underlying data endpoints (`overallLoad/graph`, `overallLoad/api/json`, and the `unlabeledLoad` equivalents) have no permission check of their own either, independently of this page-level fix - so they remain reachable by any `Overall/Read` user. That's a separate, narrower gap (it doesn't affect this page's own gating, and touches a class shared with per-node load statistics that must stay at the `Overall/Read` baseline), so I've filed it as its own PR rather than folding it into this one; will link it here once opened.

## Testing done

- `StatisticsLinkReadOnlyModeTest`: 4/4 passing
- `mvn spotless:check checkstyle:check`: clean