### PR TITLE
Fix incorrect return description in unquote Javadoc

### DIFF
--- a/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
+++ b/cli/src/main/java/hudson/util/QuotedStringTokenizer.java
@@ -430,7 +430,7 @@ public class QuotedStringTokenizer
     /* ------------------------------------------------------------ */
     /** Unquote a string.
      * @param s The string to unquote.
-     * @return quoted string
+     * @return unquoted string
      */
     public static String unquote(String s)
     {


### PR DESCRIPTION
Correct the Javadoc return description of `unquote`.

The method returns an unquoted string, but the current Javadoc incorrectly
describes the return value as a "quoted string".

### Testing done

This is a documentation-only change and does not modify runtime behavior.

Manually verified the existing behavior of `unquote`:
- `unquote("\"hello\"")` returns `hello`.
- `unquote("'hello'")` returns `hello`.

This confirms that the method returns an unquoted string, while the existing
Javadoc incorrectly describes the return value as a "quoted string".

No automated test was added because the implementation is unchanged.

### Screenshots (UI changes only)

#### Before

N/A

#### After

N/A

### Proposed changelog entries

N/A

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title.
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.