### PR TITLE
Avoid blocking Queue.lock during cloud agent termination

### DIFF
--- a/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java
+++ b/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java
@@ -29,7 +29,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.logging.Level.WARNING;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.io.IOException;
+import hudson.model.Computer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.util.SystemProperties;
@@ -44,6 +44,7 @@ import net.jcip.annotations.GuardedBy;
  */
 public class CloudRetentionStrategy extends RetentionStrategy<AbstractCloudComputer> {
     private int idleMinutes;
+    private transient boolean terminating;
 
     public CloudRetentionStrategy(int idleMinutes) {
         this.idleMinutes = idleMinutes;
@@ -53,15 +54,22 @@ public class CloudRetentionStrategy extends RetentionStrategy<AbstractCloudCompu
     @GuardedBy("hudson.model.Queue.lock")
     public long check(final AbstractCloudComputer c) {
         final AbstractCloudSlave computerNode = c.getNode();
-        if (c.isIdle() && !disabled && computerNode != null) {
+        if (c.isIdle() && !disabled && computerNode != null && !terminating) {
             final long idleMilliseconds = System.currentTimeMillis() - c.getIdleStartMilliseconds();
             if (idleMilliseconds > MINUTES.toMillis(idleMinutes)) {
+                terminating = true;
+                c.setAcceptingTasks(false);
                 LOGGER.log(Level.INFO, "Disconnecting {0}", c.getName());
-                try {
-                    computerNode.terminate();
-                } catch (InterruptedException | IOException e) {
-                    LOGGER.log(WARNING, "Failed to terminate " + c.getName(), e);
-                }
+                Computer.threadPoolForRemoting.submit(() -> {
+                    try {
+                        computerNode.terminate();
+                    } catch (Exception e) {
+                        if (e instanceof InterruptedException) {
+                            Thread.currentThread().interrupt();
+                        }
+                        LOGGER.log(WARNING, "Failed to terminate " + c.getName(), e);
+                    }
+                });
             }
         }
         return 0;

--- a/test/src/test/java/hudson/slaves/CloudRetentionStrategyTest.java
+++ b/test/src/test/java/hudson/slaves/CloudRetentionStrategyTest.java
@@ -1,0 +1,199 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2026 Preetham.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.slaves;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.jvnet.hudson.test.LoggerRule.recorded;
+
+import hudson.model.Descriptor;
+import hudson.model.Queue;
+import hudson.model.TaskListener;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class CloudRetentionStrategyTest {
+
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+    }
+
+    @Test
+    @Issue("JENKINS-27215")
+    void checkDoesNotHoldQueueLockDuringTermination() throws Exception {
+        CountDownLatch terminateStartedLatch = new CountDownLatch(1);
+        CountDownLatch unblockTerminateLatch = new CountDownLatch(1);
+        CountDownLatch terminateCompletedLatch = new CountDownLatch(1);
+        AtomicInteger terminateCallCount = new AtomicInteger(0);
+
+        SlowCloudSlave slave = new SlowCloudSlave(
+                "slow-cloud-agent",
+                j.createTmpDir().getPath(),
+                j.createComputerLauncher(null),
+                terminateStartedLatch,
+                unblockTerminateLatch,
+                terminateCompletedLatch,
+                terminateCallCount,
+                false
+        );
+
+        j.jenkins.addNode(slave);
+        AbstractCloudComputer<?> computer = (AbstractCloudComputer<?>) slave.toComputer();
+        assertNotNull(computer);
+
+        CloudRetentionStrategy strategy = (CloudRetentionStrategy) slave.getRetentionStrategy();
+
+        // Trigger retention check under Queue lock
+        Queue.runWithLock(() -> strategy.check(computer));
+
+        // Wait until background termination task enters _terminate()
+        assertTrue(terminateStartedLatch.await(10, TimeUnit.SECONDS), "Termination should start in background");
+
+        // Verify computer stops accepting tasks
+        assertFalse(computer.isAcceptingTasks(), "Computer should no longer accept tasks during termination");
+
+        // While _terminate() is STILL blocked on unblockTerminateLatch, verify another thread can acquire Queue.lock
+        AtomicBoolean lockAcquiredByOtherThread = new AtomicBoolean(false);
+        Thread otherThread = new Thread(() -> Queue.runWithLock(() -> lockAcquiredByOtherThread.set(true)));
+        otherThread.start();
+        otherThread.join(5000);
+
+        assertTrue(lockAcquiredByOtherThread.get(), "Queue.lock must NOT be held while _terminate() is blocked");
+
+        // Verify duplicate check calls do not trigger second termination
+        Queue.runWithLock(() -> strategy.check(computer));
+        assertEquals(1, terminateCallCount.get(), "Duplicate termination should not be triggered");
+
+        // Unblock termination and verify cleanup completes
+        unblockTerminateLatch.countDown();
+        assertTrue(terminateCompletedLatch.await(10, TimeUnit.SECONDS), "Termination task should complete");
+    }
+
+    @Test
+    @Issue("JENKINS-27215")
+    void terminationHandlesExceptionGracefully() throws Exception {
+        LoggerRule loggerRule = new LoggerRule().record(CloudRetentionStrategy.class, Level.WARNING).capture(100);
+
+        CountDownLatch terminateStartedLatch = new CountDownLatch(1);
+        CountDownLatch unblockTerminateLatch = new CountDownLatch(1);
+        CountDownLatch terminateCompletedLatch = new CountDownLatch(1);
+        AtomicInteger terminateCallCount = new AtomicInteger(0);
+
+        SlowCloudSlave slave = new SlowCloudSlave(
+                "failing-cloud-agent",
+                j.createTmpDir().getPath(),
+                j.createComputerLauncher(null),
+                terminateStartedLatch,
+                unblockTerminateLatch,
+                terminateCompletedLatch,
+                terminateCallCount,
+                true
+        );
+
+        j.jenkins.addNode(slave);
+        AbstractCloudComputer<?> computer = (AbstractCloudComputer<?>) slave.toComputer();
+        assertNotNull(computer);
+
+        CloudRetentionStrategy strategy = (CloudRetentionStrategy) slave.getRetentionStrategy();
+
+        Queue.runWithLock(() -> strategy.check(computer));
+
+        assertTrue(terminateStartedLatch.await(10, TimeUnit.SECONDS), "Termination should start in background");
+
+        // Unblock termination which throws IOException
+        unblockTerminateLatch.countDown();
+
+        // Verify the async task completes its execution
+        assertTrue(terminateCompletedLatch.await(10, TimeUnit.SECONDS), "Termination task should complete despite exception");
+        assertEquals(1, terminateCallCount.get(), "Termination should have been attempted exactly once");
+
+        // Verify that the warning log was produced by CloudRetentionStrategy's catch block
+        assertThat(loggerRule, recorded(Level.WARNING, containsString("Failed to terminate failing-cloud-agent")));
+    }
+
+    private static class SlowCloudSlave extends AbstractCloudSlave {
+        private final transient CountDownLatch terminateStartedLatch;
+        private final transient CountDownLatch unblockTerminateLatch;
+        private final transient CountDownLatch terminateCompletedLatch;
+        private final transient AtomicInteger terminateCallCount;
+        private final boolean throwException;
+
+        SlowCloudSlave(
+                String name,
+                String remoteFS,
+                ComputerLauncher launcher,
+                CountDownLatch terminateStartedLatch,
+                CountDownLatch unblockTerminateLatch,
+                CountDownLatch terminateCompletedLatch,
+                AtomicInteger terminateCallCount,
+                boolean throwException
+        ) throws Descriptor.FormException, IOException {
+            super(name, remoteFS, launcher);
+            setRetentionStrategy(new CloudRetentionStrategy(0));
+            this.terminateStartedLatch = terminateStartedLatch;
+            this.unblockTerminateLatch = unblockTerminateLatch;
+            this.terminateCompletedLatch = terminateCompletedLatch;
+            this.terminateCallCount = terminateCallCount;
+            this.throwException = throwException;
+        }
+
+        @Override
+        public AbstractCloudComputer<?> createComputer() {
+            return new AbstractCloudComputer<>(this);
+        }
+
+        @Override
+        protected void _terminate(TaskListener listener) throws IOException, InterruptedException {
+            try {
+                terminateCallCount.incrementAndGet();
+                terminateStartedLatch.countDown();
+                unblockTerminateLatch.await();
+                if (throwException) {
+                    throw new IOException("Simulated cloud API termination failure");
+                }
+            } finally {
+                terminateCompletedLatch.countDown();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #27215

Cloud agent termination currently happens synchronously from `CloudRetentionStrategy.check()` while `Queue.lock` is held. Since `_terminate()` may perform a cloud-provider API call, a slow or unavailable provider can keep the global queue lock held and affect scheduling for unrelated jobs.

This change dispatches `computerNode.terminate()` asynchronously using `Computer.threadPoolForRemoting`. The termination decision and state changes remain under `Queue.lock`, while the potentially blocking termination operation runs after the lock is released.

A `terminating` flag prevents duplicate termination requests, and the computer is marked as not accepting tasks before the asynchronous termination is scheduled.

### Testing done

Added regression coverage in `CloudRetentionStrategyTest` for:

- verifying that `Queue.lock` can still be acquired while `_terminate()` is blocked;
- verifying that the computer stops accepting tasks when termination starts;
- verifying that repeated retention checks do not schedule duplicate termination;
- verifying that termination exceptions are handled and logged correctly.

The tests use `CountDownLatch` for deterministic synchronization and Jenkins' `LoggerRule` for verifying the warning log.

Test executed:

`mvn test -pl test "-Dtest=CloudRetentionStrategyTest"`

Result: 2 tests passed, 0 failures, 0 errors.

### Screenshots (UI changes only)

#### Before

#### After

### Proposed changelog entries

- Avoid blocking Jenkins scheduling while terminating cloud agents

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin.
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention