### PR TITLE
[JENKINS-62465] Add page locale to the HTML tag

### DIFF
--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -101,7 +101,7 @@ THE SOFTWARE.
   </j:if>
 </j:if>
 <x:doctype name="html" />
-<html data-disable-sticky="${h.stickyPositioningDisabled}">
+<html lang="${h.getCurrentLocale().toLanguageTag()}" data-disable-sticky="${h.stickyPositioningDisabled}">
   <head data-rooturl="${rootURL}" data-resurl="${resURL}" data-imagesurl="${imagesURL}" resURL="${resURL}"
         data-extensions-available="${extensionsAvailable}"
         data-crumb-header="${h.getCrumbRequestField()}" data-crumb-value="${h.getCrumb(request2)}"


### PR DESCRIPTION
Fixes #11556

### Testing done

Built the war (`mvn -am -pl war,bom -Pquick-build clean install`) and ran a local
instance (`java -jar war/target/jenkins.war --httpPort=8090`) with the change applied.

Confirmed via curl/view-source that the root `<html>` element rendered by
`layout.jelly` now carries a correct BCP-47 `lang` attribute, both with the
JVM's default locale and honoring the browser's `Accept-Language` header:

```
curl http://localhost:8090/login
-> <html data-disable-sticky="false" lang="es-ES">

curl -H "Accept-Language: en-US,en;q=0.9" http://localhost:8090/login
-> <html data-disable-sticky="false" lang="en-US">
```

Screenshots below show the same result via Chrome's view-source.

No automated test added: this is a one-line template change reusing the
existing, already-tested `Functions.getCurrentLocale()` helper, consistent
with the sibling accessibility fixes in this epic (#4740, #5634, #7956),
none of which added tests either.

### Screenshots (UI changes only)

This change has no visible/rendered UI impact (the `lang` attribute is not
rendered), so these show the page source instead of a visual diff.

#### Before

No `lang` attribute present on `layout.jelly`'s `<html>` tag.

#### After

`es-ES` (default locale):
![after-es-ES](https://raw.githubusercontent.com/Racknaraock/jenkins/108dc69893f65996e65fccae9045d20647445ae6/JENKINS-62465/after-01-viewsource-login-es-ES.png)

`en-US` (via `Accept-Language`):
![after-en-US](https://raw.githubusercontent.com/Racknaraock/jenkins/108dc69893f65996e65fccae9045d20647445ae6/JENKINS-62465/after-02-viewsource-login-en-US.png)

### Proposed changelog entries

- Add the page's locale to the root `<html>` tag

### Proposed changelog category

/label web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see examples). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin. In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives.
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/sig-ux

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title.
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
