### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/publish-release-artifact.yml
+++ b/.github/workflows/publish-release-artifact.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up JDK 21
-        uses: actions/setup-java@1d018f9b8b9b505bb578a83b230fabcce01af93b #v 5.0.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: "temurin"
           java-version: 21


### PR DESCRIPTION
Upgrade the release artifact workflow from `actions/setup-java` v5.0.0 to v6.0.0 while retaining the SHA pin.

### Testing done

Verified the v6.0.0 tag SHA, ran `git diff --check`, and confirmed no pre-v6 `actions/setup-java` references remain in active workflows. No runtime tests were run because this is a workflow-only action update.

### Screenshots (UI changes only)

#### Before

N/A

#### After

N/A

### Proposed changelog entries

- N/A (CI workflow maintenance only)

### Proposed changelog category

/label skip-changelog

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described. (No issue needed for this minor improvement.)
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. (N/A)
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. (N/A)
- [x] UI changes do not introduce CSP regressions. (N/A)
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials: https://github.com/actions/setup-java/releases/tag/v6.0.0
- [x] For new APIs and extension points, there is a link to at least one consumer. (N/A)

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section.
- [ ] If it would make sense to backport the change to LTS, the issue or pull request is labeled `lts-candidate`.
