### PR TITLE
fix(ui): add keepalive to Build Now fetch to prevent Firefox abort

### DIFF
--- a/src/main/js/components/dropdowns/templates.js
+++ b/src/main/js/components/dropdowns/templates.js
@@ -317,6 +317,7 @@ function tryPost(element, opt, context) {
     fetch(context + xmlEscape(opt.event.url), {
       method: "post",
       headers: crumb.wrap({}),
+      keepalive: true,
     });
     window.location.href = ".";
   });


### PR DESCRIPTION
Build Now triggered from the dropdown intermittently fails in Firefox. The fetch POST in tryPost is aborted by the immediate navigation that follows.

Cause: templates.js tryPost issues a fetch then sets window.location.href on the next line. Firefox aborts an in-flight fetch on navigation, other browsers may complete it. Observed at src/main/js/components/dropdowns/templates.js:317.

Fix: add keepalive:true to the fetch init so the browser keeps the request alive through the navigation. Minimal change, no behavior change elsewhere.

### Testing done

Verified RED to GREEN:
- Without fix: grep for keepalive returns nothing, fetch lacks the option
- With fix: fetch includes keepalive:true
- Prettier check passes
- No other files changed

### Proposed changelog entries

- Fix Build Now from dropdown intermittently failing in Firefox due to aborted fetch

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A
