### PR TITLE
Fix validate button error response

### DIFF
--- a/src/test/js/form-checker.test.js
+++ b/src/test/js/form-checker.test.js
@@ -1,3 +1,4 @@
+/* global formatValidationResponse */
 import hudsonBehaviorSource from "../../../war/src/main/webapp/scripts/hudson-behavior.js?raw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -15,6 +16,34 @@ function loadHudsonBehavior() {
   // indirect eval, so that the top level `var`s of the script become globals
   (0, eval)(hudsonBehaviorSource);
 }
+
+describe("formatValidationResponse", () => {
+  beforeEach(() => {
+    loadHudsonBehavior();
+  });
+
+  it("shows a concise message for an error response", () => {
+    const response = {
+      ok: false,
+      status: 500,
+    };
+    const responseText = "<html><body><h1>Oops!</h1></body></html>";
+
+    expect(formatValidationResponse(response, responseText)).toBe(
+      '<div class="error">An internal error occurred during form field validation (HTTP 500). Please reload the page and if the problem persists, ask the administrator for help.</div>',
+    );
+  });
+
+  it("returns the response body for a successful response", () => {
+    const response = {
+      ok: true,
+      status: 200,
+    };
+    const responseText = "<div>Validation successful</div>";
+
+    expect(formatValidationResponse(response, responseText)).toBe(responseText);
+  });
+});
 
 describe("FormChecker.delayedCheck", () => {
   /** The requests handed to fetch, each one settled by the test. */

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -677,6 +677,13 @@ function fireEvent(element, event) {
   );
 }
 
+function formatValidationResponse(response, responseText) {
+  // TODO Add i18n support
+  return response.ok
+    ? responseText
+    : `<div class="error">An internal error occurred during form field validation (HTTP ${response.status}). Please reload the page and if the problem persists, ask the administrator for help.</div>`;
+}
+
 // Behavior rules
 //========================================================
 // using tag names in CSS selector makes the processing faster
@@ -2719,7 +2726,10 @@ function validateButton(checkUrl, paramList, button) {
     rsp.text().then((responseText) => {
       spinner.style.display = "none";
       target.innerHTML = `<div class="validation-error-area" />`;
-      updateValidationArea(target.children[0], responseText);
+      updateValidationArea(
+        target.children[0],
+        formatValidationResponse(rsp, responseText),
+      );
       layoutUpdateCallback.call();
       let json = rsp.headers.get("X-Jenkins-ValidateButton-Callback");
       if (json != null) {


### PR DESCRIPTION
<!-- No issue; this is a minor bug fix. -->

### Testing done

Added automated tests for `formatValidationResponse` covering both successful and error responses.

Ran:

`corepack yarn vitest run src/test/js/form-checker.test.js`

Result:

- 1 test file passed
- 7 tests passed
- `git diff --check` passed

The change updates `validateButton` to display a concise error message when the validation request returns a non-success HTTP response instead of displaying the raw server response.

### Screenshots (UI changes only)

<!--
This is a user-visible frontend behavior change, but screenshots are not available because the error response scenario is covered by automated tests.
-->

#### Before

N/A

#### After

N/A

### Proposed changelog entries

- Show a concise error message when form field validation fails

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by this change (users or developers, depending on the change). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin (CSP). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of CSP directives.
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@jenkinsci/core-pr-reviewers