### PR TITLE
Bound Cloud.provision() to a timeout so it cannot block the shared Timer pool

### DIFF
--- a/core/src/main/java/hudson/slaves/NodeProvisioner.java
+++ b/core/src/main/java/hudson/slaves/NodeProvisioner.java
@@ -48,9 +48,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -724,9 +728,7 @@ public class NodeProvisioner {
                                 }
                             }
 
-                            Collection<PlannedNode> additionalCapacities = c.provision(cloudState, workloadToProvision);
-
-                            fireOnStarted(c, state.getLabel(), additionalCapacities);
+                            Collection<PlannedNode> additionalCapacities = provisionWithTimeout(c, cloudState, workloadToProvision, state);
 
                             for (PlannedNode ac : additionalCapacities) {
                                 excessWorkload -= ac.numExecutors;
@@ -734,7 +736,6 @@ public class NodeProvisioner {
                                                 + "executors. Remaining excess workload: {3,number,#.###}",
                                         new Object[]{ac.displayName, c.name, ac.numExecutors, excessWorkload});
                             }
-                            state.recordPendingLaunches(additionalCapacities);
                         }
                     }
                     // we took action, only pass on to other strategies if our action was insufficient
@@ -744,6 +745,85 @@ public class NodeProvisioner {
             // if we reach here then the standard strategy obviously decided to do nothing, so let any other strategies
             // take their considerations.
             return StrategyDecision.CONSULT_REMAINING_STRATEGIES;
+        }
+
+        /**
+         * Maximum time, in milliseconds, that {@link #apply(StrategyState)} will wait for a single
+         * {@link Cloud#provision} call to return before moving on to the next cloud/strategy.
+         *
+         * <p>{@link Cloud#provision} is documented to start provisioning asynchronously, but this is not
+         * enforced: {@link #apply(StrategyState)} runs on the shared {@link jenkins.util.Timer} pool (via
+         * {@link NodeProvisionerInvoker}), which is also used for every other periodic task in Jenkins core
+         * and in plugins. A {@link Cloud} implementation that blocks on a slow or hung provider API inside
+         * {@link Cloud#provision} would otherwise tie up one of that pool's few threads for the duration of
+         * the call. This timeout bounds that exposure: once it elapses, the call is left to complete in the
+         * background on {@link Computer#threadPoolForRemoting} instead, and its result (if any) is applied
+         * once it arrives, rather than blocking the calling thread any further.
+         */
+        private static final long PROVISION_TIMEOUT_MS = SystemProperties.getLong(
+                NodeProvisioner.class.getName() + ".provisionTimeoutMillis", TimeUnit.SECONDS.toMillis(30));
+
+        /**
+         * Cloud/label pairs with a {@link Cloud#provision} call currently running past
+         * {@link #PROVISION_TIMEOUT_MS} in the background. Prevents {@link #apply(StrategyState)}, on a
+         * later cycle, from issuing another provisioning request for the same demand before the first one
+         * has had a chance to report back via {@link StrategyState#recordPendingLaunches}.
+         */
+        private static final Set<String> PENDING_PROVISION_REQUESTS = ConcurrentHashMap.newKeySet();
+
+        /**
+         * Calls {@link Cloud#provision} with a bound on how long the calling thread will wait for it to
+         * return. If the call does not complete within {@link #PROVISION_TIMEOUT_MS}, an empty collection is
+         * returned immediately so provisioning can proceed with the next cloud/strategy, and the original
+         * call is left running on {@link Computer#threadPoolForRemoting}; its result is applied
+         * ({@link #fireOnStarted} and {@link StrategyState#recordPendingLaunches}) once it completes, whether
+         * that happens before or after the timeout. While that background call is outstanding, further
+         * calls for the same cloud/label are skipped rather than piling up duplicate requests.
+         */
+        private static Collection<PlannedNode> provisionWithTimeout(Cloud c, Cloud.CloudState cloudState, int workloadToProvision, StrategyState state) {
+            Label label = state.getLabel();
+            String key = c.name + "::" + (label == null ? "" : label.getName());
+            if (!PENDING_PROVISION_REQUESTS.add(key)) {
+                LOGGER.log(Level.FINE, "Skipping provision() for cloud {0}; a previous call for the same "
+                        + "label has not completed yet", c.name);
+                return List.of();
+            }
+
+            CompletableFuture<Collection<PlannedNode>> provisionFuture = CompletableFuture.supplyAsync(
+                    () -> c.provision(cloudState, workloadToProvision), Computer.threadPoolForRemoting);
+
+            provisionFuture.whenComplete((additionalCapacities, error) -> {
+                PENDING_PROVISION_REQUESTS.remove(key);
+                if (error != null) {
+                    LOGGER.log(Level.WARNING, "Cloud " + c.name + " failed to provision", error);
+                    return;
+                }
+                fireOnStarted(c, label, additionalCapacities);
+                state.recordPendingLaunches(additionalCapacities);
+            });
+
+            try {
+                return provisionFuture.get(PROVISION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException e) {
+                LOGGER.log(Level.WARNING,
+                        "Cloud {0} did not return from provision() within {1}ms; not waiting any longer so as to "
+                                + "avoid blocking other provisioning work. It will keep running in the background "
+                                + "and its result, if any, will be applied once it completes.",
+                        new Object[]{c.name, PROVISION_TIMEOUT_MS});
+                return List.of();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return List.of();
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException re) {
+                    throw re;
+                }
+                if (cause instanceof Error er) {
+                    throw er;
+                }
+                throw new RuntimeException(cause);
+            }
         }
 
         /**

--- a/test/src/test/java/hudson/slaves/NodeProvisionerTest.java
+++ b/test/src/test/java/hudson/slaves/NodeProvisionerTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import hudson.BulkChange;
@@ -52,6 +53,7 @@ import hudson.model.queue.QueueTaskFuture;
 import hudson.tasks.Builder;
 import io.jenkins.lib.support_log_formatter.SupportLogFormatter;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -62,6 +64,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -88,7 +92,10 @@ class NodeProvisionerTest {
         rr.javaOptions(
                 "-Dhudson.model.LoadStatistics.clock=" + TimeUnit.SECONDS.toMillis(1),
                 "-Dhudson.slaves.NodeProvisioner.initialDelay=" + TimeUnit.SECONDS.toMillis(10),
-                "-Dhudson.slaves.NodeProvisioner.recurrencePeriod=" + TimeUnit.SECONDS.toMillis(1));
+                "-Dhudson.slaves.NodeProvisioner.recurrencePeriod=" + TimeUnit.SECONDS.toMillis(1),
+                // short enough to keep the timeout test below fast, long enough that none of the other
+                // (fast-returning) DummyCloudImpl-based tests in this class come anywhere close to it
+                "-Dhudson.slaves.NodeProvisioner.provisionTimeoutMillis=" + TimeUnit.SECONDS.toMillis(5));
     }
 
     /**
@@ -315,6 +322,104 @@ class NodeProvisionerTest {
 
         assertEquals(1, cloud1.numProvisioned);
         assertEquals(0, cloud2.numProvisioned);
+    }
+
+    /**
+     * A {@link Cloud#provision} implementation that blocks past the configured
+     * {@code hudson.slaves.NodeProvisioner.provisionTimeoutMillis} should not keep
+     * {@code NodeProvisioner}'s internal lock (and thus the calling thread) blocked for the
+     * duration of the call; the lock must be released once the timeout elapses, and the deferred
+     * result must still be applied once the call eventually completes.
+     */
+    @Issue("JENKINS-27308")
+    @Test
+    void slowCloudProvisionDoesNotBlockProvisioningLock() throws Throwable {
+        assumeFalse(Functions.isWindows() && System.getenv("CI") != null, "TODO: Windows container agents do not have enough resources to run this test");
+        rr.then(NodeProvisionerTest::_slowCloudProvisionDoesNotBlockProvisioningLock);
+    }
+
+    private static void _slowCloudProvisionDoesNotBlockProvisioningLock(JenkinsRule r) throws Exception {
+        CountDownLatch provisionStarted = new CountDownLatch(1);
+        CountDownLatch unblockProvision = new CountDownLatch(1);
+        CountDownLatch provisionCompleted = new CountDownLatch(1);
+        AtomicInteger provisionCallCount = new AtomicInteger(0);
+
+        SlowCloudImpl cloud = new SlowCloudImpl(r, provisionStarted, unblockProvision, provisionCompleted, provisionCallCount);
+        r.jenkins.clouds.add(cloud);
+        r.jenkins.setNumExecutors(0);
+        r.jenkins.setNodes(Collections.emptyList());
+
+        FreeStyleProject p = createJob(new SleepBuilder(1), r);
+        p.scheduleBuild2(0);
+
+        assertTrue(provisionStarted.await(30, TimeUnit.SECONDS), "cloud.provision() should have been invoked");
+
+        // provisioningLock must be released once provision()'s timeout elapses, well before
+        // unblockProvision is counted down below, proving the calling thread does not stay blocked
+        // for the whole duration of a slow/hung Cloud#provision call.
+        Field lockField = NodeProvisioner.class.getDeclaredField("provisioningLock");
+        lockField.setAccessible(true);
+        Lock provisioningLock = (Lock) lockField.get(r.jenkins.unlabeledNodeProvisioner);
+        assertTrue(provisioningLock.tryLock(15, TimeUnit.SECONDS),
+                "provisioningLock should be released once provision() exceeds its configured timeout, "
+                        + "not held until the slow provision() call actually returns");
+        provisioningLock.unlock();
+
+        // provision() is still running in the background at this point; let it finish and confirm its
+        // (late) result is still applied rather than silently dropped.
+        unblockProvision.countDown();
+        assertTrue(provisionCompleted.await(30, TimeUnit.SECONDS), "provision() should eventually complete in the background");
+        assertEquals(1, provisionCallCount.get(), "provision() should not be invoked more than once for the same demand");
+    }
+
+    private static class SlowCloudImpl extends Cloud {
+        private final transient JenkinsRule caller;
+        private final transient CountDownLatch provisionStarted;
+        private final transient CountDownLatch unblockProvision;
+        private final transient CountDownLatch provisionCompleted;
+        private final transient AtomicInteger provisionCallCount;
+
+        SlowCloudImpl(JenkinsRule caller, CountDownLatch provisionStarted, CountDownLatch unblockProvision,
+                      CountDownLatch provisionCompleted, AtomicInteger provisionCallCount) {
+            super("SlowCloudImpl");
+            this.caller = caller;
+            this.provisionStarted = provisionStarted;
+            this.unblockProvision = unblockProvision;
+            this.provisionCompleted = provisionCompleted;
+            this.provisionCallCount = provisionCallCount;
+        }
+
+        @Override
+        public Collection<NodeProvisioner.PlannedNode> provision(Label label, int excessWorkload) {
+            provisionCallCount.incrementAndGet();
+            provisionStarted.countDown();
+            try {
+                unblockProvision.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return List.of();
+            }
+            List<NodeProvisioner.PlannedNode> result = new ArrayList<>();
+            Future<Node> f = Computer.threadPoolForRemoting.submit(() -> {
+                DumbSlave slave = caller.createSlave(label);
+                Computer computer = slave.toComputer();
+                computer.connect(false).get();
+                return slave;
+            });
+            result.add(new NodeProvisioner.PlannedNode(name + " #1", f, 1));
+            provisionCompleted.countDown();
+            return result;
+        }
+
+        @Override
+        public boolean canProvision(Label label) {
+            return true;
+        }
+
+        @Override
+        public Descriptor<Cloud> getDescriptor() {
+            throw new UnsupportedOperationException();
+        }
     }
 
     private static class DummyCloudImpl3 extends Cloud {


### PR DESCRIPTION
Fixes #27308.

`NodeProvisioner.StandardStrategyImpl.apply()` called `Cloud.provision()` synchronously while holding `provisioningLock`, on the thread dispatched by `NodeProvisionerInvoker`, a `PeriodicWork` that runs on the shared `jenkins.util.Timer` pool (only 10 threads, used by every periodic task in core and in plugins). `Cloud.provision()` is documented as asynchronous, but core did not enforce that boundary in any way: a cloud implementation that blocks on a slow or hung provider API inside `provision()` could tie up one of those 10 threads for as long as that call takes. This is not hypothetical: docker-plugin's `DockerCloud.provision()` makes a synchronous Docker daemon API call before deferring container creation.

This PR bounds the call with a configurable timeout (`hudson.slaves.NodeProvisioner.provisionTimeoutMillis`, default 30s). If `provision()` does not return within that time, the calling thread stops waiting and moves on; the call keeps running in the background on `Computer.threadPoolForRemoting`, and its result (the `PlannedNode`s, if any) is applied once it completes, whether that is before or after the timeout. A cloud/label pair with a call still outstanding is skipped on subsequent cycles rather than piling up duplicate provisioning requests for the same demand.

In the common case, where `provision()` returns quickly, behavior is unchanged.

### Testing done

Added `NodeProvisionerTest#slowCloudProvisionDoesNotBlockProvisioningLock`, which drives a `Cloud` whose `provision()` blocks on a latch past the configured timeout, and verifies:
- `provisioningLock` is released (via reflection + `tryLock`) once the timeout elapses, well before the cloud's `provision()` call actually returns.
- `provision()` is not invoked again for the same cloud/label while the first call is still outstanding.
- Once the blocked call is unblocked and completes, its result is still applied.

Ran this test plus the rest of `NodeProvisionerTest` locally against JDK 21; all pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
