### PR TITLE
enable UserProperties to be removed

### DIFF
--- a/core/src/main/java/hudson/model/User.java
+++ b/core/src/main/java/hudson/model/User.java
@@ -387,6 +387,19 @@ public class User extends AbstractModelObject implements AccessControlled, Descr
     }
 
     /**
+     * Remove the property for the given class from List of User properties
+     */
+    public synchronized<T extends UserProperty> void removeProperty(@NonNull Class<T> clazz) throws IOException {
+        List<UserProperty> ps = new ArrayList<>(properties);
+        T oldProp = getProperty(clazz);
+        if (oldProp != null) {
+            ps.remove(oldProp);
+            properties = ps;
+            save();
+        }
+    }
+
+    /**
      * List of all {@link UserProperty}s exposed primarily for the remoting API.
      */
     @Exported(name = "property", inline = true)

--- a/test/src/test/java/hudson/model/UserTest.java
+++ b/test/src/test/java/hudson/model/UserTest.java
@@ -26,11 +26,14 @@
 package hudson.model;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.IsIterableContaining.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -147,7 +150,18 @@ class UserTest {
       }
     }
 
-    @Issue("JENKINS-2331")
+    @Test
+    void userPropertiesCanBeRemoved() throws Exception {
+        UserProperty testProperty = new UserPropertyImpl("Needle");
+
+        User user = User.getById("user-test-case", true);
+        int numberOfProperties = user.getAllProperties().size();
+        user.addProperty(testProperty);
+        assertThat(user.getAllProperties(), allOf(hasSize(numberOfProperties+1), hasItem(testProperty)));
+        user.removeProperty(UserPropertyImpl.class);
+        assertThat(user.getAllProperties(), allOf(hasSize(numberOfProperties), not(hasItem(testProperty))));
+    }
+
     @Test
     void userPropertySummaryAndActionAreShownInUserPage() throws Exception {
 
@@ -163,6 +177,7 @@ class UserTest {
         WebAssert.assertTextPresentInElement(page, ((Action) property).getDisplayName(), "side-panel");
 
     }
+
 
     /**
      * Asserts that the default user avatar can be fetched (ie no 404)


### PR DESCRIPTION
User properties could be added in one of two ways:

1. programmatically via `addProperty`/`addProperties`
2. as a default property from the `Descriptor`'s `newInstance(User)` method

However the only way to remove one was to implement a `readResolve` that returned `null` when it was next loaded.

This limitation caused properties to be more complicated than needed as they need to handle the case that they have been added but are no longer valid rather than just assume that a property would always be valid.

As such implement a new API so that a Property can be removed by its class. Whilst removing by class may seem odd, you can only have a single instance of a given class in the property list.
Using a class also means that any code wanting to remove a property does not need to duplicate the getting of the property, checking its not null before attempting to remove it.

<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

implemented a new Unit test
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- Introduce a new API to allow plugins to remove a specific `UserProperty` from a `User`

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label <update-this-with-category>

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
