### PR TITLE
Fix nested repeatable visibility for delete controls

### DIFF
--- a/src/main/scss/form/_reorderable-list.scss
+++ b/src/main/scss/form/_reorderable-list.scss
@@ -233,78 +233,31 @@ div.repeated-chunk {
 
 /* ========================= repeatable elements ========================= */
 
-.repeated-chunk .show-if-last {
-  visibility: hidden;
-}
+.repeated-chunk {
+  --repeatable-show-if-last: hidden;
+  --repeatable-show-if-not-last: visible;
+  --repeatable-show-if-not-only: visible;
 
-.repeated-chunk.last .show-if-last {
-  visibility: visible;
-}
+  &.last {
+    --repeatable-show-if-last: visible;
+    --repeatable-show-if-not-last: hidden;
+  }
 
-.repeated-chunk .show-if-not-last {
-  visibility: visible;
-}
+  &.first.last {
+    --repeatable-show-if-not-only: hidden;
+  }
 
-.repeated-chunk.last .show-if-not-last {
-  visibility: hidden;
-}
+  .show-if-last {
+    visibility: var(--repeatable-show-if-last);
+  }
 
-.repeated-chunk .show-if-not-only {
-  visibility: visible;
-}
+  .show-if-not-last {
+    visibility: var(--repeatable-show-if-not-last);
+  }
 
-.repeated-chunk.first.last .show-if-not-only {
-  visibility: hidden;
-}
-
-/* == nested repeatable elements / 2 deep == */
-.repeated-chunk .repeated-chunk .show-if-last {
-  visibility: hidden;
-}
-
-.repeated-chunk .repeated-chunk.last .show-if-last {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk .show-if-not-last {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk.last .show-if-not-last {
-  visibility: hidden;
-}
-
-.repeated-chunk .repeated-chunk .show-if-not-only {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk.first.last .show-if-not-only {
-  visibility: hidden;
-}
-
-/* == nested repeatable elements / 3 deep == */
-.repeated-chunk .repeated-chunk .repeated-chunk .show-if-last {
-  visibility: hidden;
-}
-
-.repeated-chunk .repeated-chunk .repeated-chunk.last .show-if-last {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk .repeated-chunk .show-if-not-last {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk .repeated-chunk.last .show-if-not-last {
-  visibility: hidden;
-}
-
-.repeated-chunk .repeated-chunk .repeated-chunk .show-if-not-only {
-  visibility: visible;
-}
-
-.repeated-chunk .repeated-chunk .repeated-chunk.first.last .show-if-not-only {
-  visibility: hidden;
+  .show-if-not-only {
+    visibility: var(--repeatable-show-if-not-only);
+  }
 }
 
 /*

--- a/src/test/js/reorderable-list.test.js
+++ b/src/test/js/reorderable-list.test.js
@@ -1,0 +1,70 @@
+import { resolve } from "node:path";
+import { compile } from "sass";
+import { beforeAll, describe, expect, it } from "vitest";
+
+beforeAll(() => {
+  const stylesheet = document.createElement("style");
+  stylesheet.textContent = compile(
+    resolve("src/main/scss/form/_reorderable-list.scss"),
+  ).css;
+  document.head.appendChild(stylesheet);
+});
+
+function visibility(id, condition = "not-only") {
+  const style = getComputedStyle(document.getElementById(id));
+  const value = style.visibility;
+  // jsdom inherits custom properties but does not resolve var() in visibility.
+  if (value.startsWith("var(")) {
+    return style.getPropertyValue(`--repeatable-show-if-${condition}`);
+  }
+  return value;
+}
+
+describe("nested repeatable element visibility", () => {
+  it("uses the position of the nearest repeated chunk", () => {
+    document.body.innerHTML = `
+      <div class="repeated-container">
+        <div class="repeated-chunk first last only">
+          <div class="jenkins-repeated-chunk__content">
+            <button id="outer-only" class="show-if-not-only"></button>
+            <button id="outer-last" class="show-if-last"></button>
+            <button id="outer-not-last" class="show-if-not-last"></button>
+            <div class="repeated-container">
+              <div class="repeated-chunk first">
+                <div class="jenkins-repeated-chunk__content">
+                  <button id="inner-first" class="show-if-not-only"></button>
+                  <button id="inner-first-last" class="show-if-last"></button>
+                  <button id="inner-first-not-last" class="show-if-not-last"></button>
+                  <div class="repeated-container">
+                    <div class="repeated-chunk first last only">
+                      <div class="jenkins-repeated-chunk__content">
+                        <button id="deep-only" class="show-if-not-only"></button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="repeated-chunk last">
+                <div class="jenkins-repeated-chunk__content">
+                  <button id="inner-last" class="show-if-not-only"></button>
+                  <button id="inner-last-last" class="show-if-last"></button>
+                  <button id="inner-last-not-last" class="show-if-not-last"></button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>`;
+
+    expect(visibility("outer-only")).toBe("hidden");
+    expect(visibility("outer-last", "last")).toBe("visible");
+    expect(visibility("outer-not-last", "not-last")).toBe("hidden");
+    expect(visibility("inner-first")).toBe("visible");
+    expect(visibility("inner-first-last", "last")).toBe("hidden");
+    expect(visibility("inner-first-not-last", "not-last")).toBe("visible");
+    expect(visibility("inner-last")).toBe("visible");
+    expect(visibility("inner-last-last", "last")).toBe("visible");
+    expect(visibility("inner-last-not-last", "not-last")).toBe("hidden");
+    expect(visibility("deep-only")).toBe("hidden");
+  });
+});

--- a/src/test/js/reorderable-list.test.js
+++ b/src/test/js/reorderable-list.test.js
@@ -1,12 +1,14 @@
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { compile } from "sass";
 import { beforeAll, describe, expect, it } from "vitest";
 
+const here = dirname(fileURLToPath(import.meta.url));
+const scssPath = resolve(here, "../../main/scss/form/_reorderable-list.scss");
+
 beforeAll(() => {
   const stylesheet = document.createElement("style");
-  stylesheet.textContent = compile(
-    resolve("src/main/scss/form/_reorderable-list.scss"),
-  ).css;
+  stylesheet.textContent = compile(scssPath).css;
   document.head.appendChild(stylesheet);
 });
 


### PR DESCRIPTION
Fixes #27321

Related to #27267 and #27279.

### Testing done

The existing descendant selectors in `src/main/scss/form/_reorderable-list.scss` allow an outer repeatable element to affect visibility of controls belonging to an inner repeatable element.

The fix scopes repeatable visibility state to the closest `.repeated-chunk` using inherited CSS custom properties. This keeps outer repeatable state from overriding nested repeatable controls.

Added regression coverage in:
`src/test/js/reorderable-list.test.js`

Automated checks completed successfully:
- `corepack yarn test`
- `corepack yarn lint`
- `corepack yarn build`
- `mvn -am -pl war,bom -Pquick-build clean install`

Manual testing:

1. Created a Freestyle project.
2. Added the Publish Over SSH post-build action.
3. Added one SSH Publisher.
4. Added two or more nested Transfer Sets.
5. Confirmed every Transfer Set displays its delete button.
6. Deleted Transfer Sets one at a time.
7. Confirmed the delete button is hidden only when the inner list contains its minimum number of entries.
8. Confirmed that a single outer SSH Publisher does not hide controls belonging to the nested Transfer Set list.

### Screenshots (UI changes only)

#### Before
PR #27279
<img width="1919" height="1075" alt="Screenshot 2026-09-02 223105" src="https://github.com/user-attachments/assets/4e10d413-1cab-423c-b617-f59a78f1b32e" />


#### After
<img width="1919" height="1063" alt="Screenshot 2026-09-02 232057" src="https://github.com/user-attachments/assets/d6d4c6fa-38e1-4de4-ae59-d51a7dd0b468" />

### Proposed changelog entries
- Show delete controls correctly for nested repeatable entries
  
### Proposed changelog category
/label bug,web-ui

### Proposed upgrade guidelines
N/A

### Submitter checklist
- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the affected audience and are in the imperative mood.
- [x] There is automated regression coverage for the changed behavior.
- [x] No new public classes, fields, or methods were added.
- [x] No deprecations were added.
- [x] The UI change does not add inline JavaScript or introduce Content Security Policy issues.
- [x] No dependency updates are included.
- [x] No new APIs or extension points are included.

### Desired reviewers

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title.
- [ ] If it would make sense to backport the change to LTS, the issue or pull request is labeled as `lts-candidate`.