### PR TITLE
Expose the agent connection secret through the REST API

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -576,6 +576,25 @@ public class SlaveComputer extends Computer {
         }
     }
 
+    /**
+     * Just for REST API.
+     * Returns the connection secret of the inbound (JNLP) agent so that automation can provision agents without
+     * parsing the JNLP file. Requires the same permission as the JNLP file endpoint.
+     * @see #getJnlpMac()
+     * @return the connection secret or {@code null} if the caller does not have the connect permission.
+     * @since 2.581
+     */
+    @Exported
+    @Restricted(DoNotUse.class)
+    @CheckForNull
+    public String getJnlpSecret() {
+        if (hasPermission(CONNECT)) {
+            return getJnlpMac();
+        } else {
+            return null;
+        }
+    }
+
     static class LoadingCount extends MasterToSlaveCallable<Integer, RuntimeException> {
         private final boolean resource;
 

--- a/test/src/test/java/hudson/slaves/SlaveComputerTest.java
+++ b/test/src/test/java/hudson/slaves/SlaveComputerTest.java
@@ -114,6 +114,37 @@ class SlaveComputerTest {
     }
 
     @Test
+    void testGetJnlpSecret() throws Exception {
+        //default auth
+        DumbSlave nodeA = j.createOnlineSlave();
+        String secret = nodeA.getComputer().getJnlpSecret();
+        assertNotNull(secret);
+        assertEquals(getJnlpSecret(nodeA, null), secret);
+
+        //not auth
+        String userAlice = "alice";
+        MockAuthorizationStrategy authStrategy = new MockAuthorizationStrategy();
+        authStrategy.grant(Computer.CONFIGURE, Jenkins.READ).everywhere().to(userAlice);
+
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(authStrategy);
+        try (ACLContext context = ACL.as(User.getById(userAlice, true))) {
+            secret = nodeA.getComputer().getJnlpSecret();
+            assertNull(secret);
+            assertNull(getJnlpSecret(nodeA, userAlice));
+        }
+
+        //with auth
+        String userBob = "bob";
+        authStrategy.grant(Computer.CONNECT, Jenkins.READ).everywhere().to(userBob);
+        try (ACLContext context = ACL.as(User.getById(userBob, true))) {
+            secret = nodeA.getComputer().getJnlpSecret();
+            assertNotNull(secret);
+            assertEquals(secret, getJnlpSecret(nodeA, userBob));
+        }
+    }
+
+    @Test
     @Issue("JENKINS-57111")
     void startupShouldNotFailOnExceptionOnlineListener() throws Exception {
         DumbSlave nodeA = j.createOnlineSlave();
@@ -212,6 +243,21 @@ class SlaveComputerTest {
      * @throws SAXException in case of config format problem.
      */
     private String getRemoteFS(Node node, String user) throws Exception {
+        return getExportedString(node, user, "absoluteRemotePath");
+    }
+
+    /**
+     * Get the agent connection secret through the json api
+     * @param node agent node
+     * @param user the user for webClient
+     * @return the connection secret
+     * @throws Exception in case of communication problem.
+     */
+    private String getJnlpSecret(Node node, String user) throws Exception {
+        return getExportedString(node, user, "jnlpSecret");
+    }
+
+    private String getExportedString(Node node, String user, String field) throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
         if (user != null) {
             wc.login(user);
@@ -221,11 +267,11 @@ class SlaveComputerTest {
                 "application/json").getWebResponse();
         JSONObject json = JSONObject.fromObject(response.getContentAsString());
 
-        Object pathObj = json.get("absoluteRemotePath");
-        if (pathObj instanceof JSONNull) {
+        Object obj = json.get(field);
+        if (obj instanceof JSONNull) {
             return null; // the value is null in here
         } else {
-            return pathObj.toString();
+            return obj.toString();
         }
     }
 }


### PR DESCRIPTION
Fixes #27325

Automation that provisions inbound (JNLP) agents, for example with Ansible, currently has to download `jenkins-agent.jnlp` and parse the rendered XML to extract the connection secret. That couples automation to a UI endpoint and logs one false-positive `-jnlpUrl` deprecation warning per fetch (#27326).

This change exposes the secret through the existing `SlaveComputer` REST API following the same pattern as `getAbsoluteRemotePath()`:

- `@Exported`, readable with `GET /computer/<name>/api/json?tree=jnlpSecret`
- guarded with `hasPermission(CONNECT)`, the permission the JNLP file endpoint already requires (`EncryptedSlaveAgentJnlpFile(..., CONNECT)`), so no new access is granted
- `@CheckForNull`, returning `null` instead of throwing without the permission

### Testing done

`mvn -pl test test -Dtest=SlaveComputerTest` with the new `testGetJnlpSecret`:

- default security realm: the secret is returned directly and read back through `/computer/<name>/api/json`
- a user with `Agent/Configure` only gets `null`, from both the getter and the REST API
- a user with `Agent/Connect` + `Jenkins/Read` gets the same value as an administrator, through the REST API

```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0 -- in hudson.slaves.SlaveComputerTest
```

### Proposed changelog entries

- Expose the inbound agent connection secret through the REST API, gated on Agent/Connect

### Proposed changelog category

/label rfe
