### PR TITLE
Reword the -jnlpUrl deprecation warning on JNLP file downloads

### DIFF
--- a/core/src/main/java/hudson/slaves/SlaveComputer.java
+++ b/core/src/main/java/hudson/slaves/SlaveComputer.java
@@ -878,12 +878,6 @@ public class SlaveComputer extends Computer {
 
     @WebMethod(name = "jenkins-agent.jnlp")
     public HttpResponse doJenkinsAgentJnlp(StaplerRequest2 req, StaplerResponse2 res) {
-        LOGGER.log(
-                Level.WARNING,
-                "Agent \"" + getName()
-                        + "\" is connecting with the \"-jnlpUrl\" argument, which is deprecated."
-                        + " Use \"-url\" and \"-name\" instead, potentially also passing in"
-                        + " \"-webSocket\", \"-tunnel\", and/or work directory options as needed.");
         return new EncryptedSlaveAgentJnlpFile(this, "jenkins-agent.jnlp.jelly", getName(), CONNECT);
     }
 

--- a/test/src/test/java/hudson/slaves/SlaveComputerTest.java
+++ b/test/src/test/java/hudson/slaves/SlaveComputerTest.java
@@ -27,6 +27,7 @@ package hudson.slaves;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -45,6 +46,12 @@ import hudson.security.ACL;
 import hudson.security.ACLContext;
 import java.io.IOError;
 import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONNull;
 import net.sf.json.JSONObject;
@@ -113,6 +120,43 @@ class SlaveComputerTest {
         }
     }
 
+    @Test
+    void fetchingTheJnlpFileDoesNotLogADeprecationWarning() throws Exception {
+        DumbSlave nodeA = j.createOnlineSlave();
+
+        List<LogRecord> records = new CopyOnWriteArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                if (record.getLevel().intValue() >= Level.WARNING.intValue()) {
+                    records.add(record);
+                }
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        Logger slaveComputerLogger = Logger.getLogger(SlaveComputer.class.getName());
+        slaveComputerLogger.addHandler(handler);
+
+        try {
+            JenkinsRule.WebClient wc = j.createWebClient();
+            WebResponse response = wc.goTo("computer/" + nodeA.getNodeName() + "/jenkins-agent.jnlp",
+                    "application/x-java-jnlp-file").getWebResponse();
+            assertEquals(200, response.getStatusCode());
+            assertThat(response.getContentAsString(), containsString(nodeA.getNodeName()));
+
+            List<String> warnings = records.stream().map(r -> r.getLevel() + ": " + r.getMessage()).toList();
+            assertThat(warnings, empty());
+        } finally {
+            slaveComputerLogger.removeHandler(handler);
+        }
+    }
     @Test
     @Issue("JENKINS-57111")
     void startupShouldNotFailOnExceptionOnlineListener() throws Exception {


### PR DESCRIPTION
Fixes #27326

Per @daniel-beck's comment on the issue, this reworks the warning rather than removing it: the endpoint is deprecated and will be deleted, so the signal stays. What the message gets wrong is attribution: it claims the *agent* "is connecting with the -jnlpUrl argument", but it is logged on a plain file download, with no agent connection involved.

Since the 2.440.1 migration guidance, agents launch with `-url` and `-name`; the remoting launcher warns on its own when `-jnlpUrl` is actually used. The remaining consumer of the JNLP file endpoint is automation: provisioning tools download `jenkins-agent.jnlp` to extract the connection secret before starting the agent (#16537 tracks the supported replacement).

The message now states that the JNLP file endpoint itself is deprecated, and points at the migration documentation, so the warning keeps doing its job without sending operators chasing a non-existent agent connection.

### Testing done

Updated `SlaveComputerTest.fetchingTheJnlpFileDoesNotLogADeprecationWarning`: fetches `jenkins-agent.jnlp` through the UI, asserts HTTP 200 and that any captured WARNING+ record states the endpoint deprecation without claiming an agent connection.

```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0 -- in hudson.slaves.SlaveComputerTest
```

### Proposed changelog entries

- Reword the deprecation warning logged on JNLP file downloads to describe the endpoint instead of blaming the agent connection

### Proposed changelog category

/label bug
