### PR TITLE
Add support for `hudson.model.Failure` in CLI error output

### DIFF
--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -304,6 +304,10 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
                 printError(
                         "Bad Credentials. Search the server log for " + context.getCorrelationId() + " for more details.");
             }
+            case RuntimeException failure when failure.getClass().getName().equals("hudson.model.Failure") -> {
+                exitCode = 8;
+                printError(failure.getMessage());
+            }
             case null, default -> {
                 exitCode = 1;
                 printError("Unexpected exception occurred while performing " + getName() + " command.");

--- a/core/src/main/java/hudson/cli/CLICommand.java
+++ b/core/src/main/java/hudson/cli/CLICommand.java
@@ -228,7 +228,8 @@ public abstract class CLICommand implements ExtensionPoint, Cloneable {
      *      <tr><td>5</td><td>{@link AbortException} is thrown while performing the command.</td></tr>
      *      <tr><td>6</td><td>{@link AccessDeniedException} is thrown while performing the command.</td></tr>
      *      <tr><td>7</td><td>{@link BadCredentialsException} is thrown while performing the command.</td></tr>
-     *      <tr><td>8-15</td><td>are reserved for future usage.</td></tr>
+     *      <tr><td>8</td><td>{@code hudson.model.Failure} is thrown while performing the command.</td></tr>
+     *      <tr><td>9-15</td><td>are reserved for future usage.</td></tr>
      *      <tr><td>16+</td><td>a custom CLI exit error code (meaning defined by the CLI command itself)</td></tr>
      *      </table>
      *      Note: For details - see JENKINS-32273

--- a/test/src/test/java/hudson/cli/CopyJobCommandTest.java
+++ b/test/src/test/java/hudson/cli/CopyJobCommandTest.java
@@ -123,7 +123,7 @@ class CopyJobCommandTest {
 
         CLICommandInvoker.Result result = command.invokeWithArgs("job1", "job1.");
         assertThat(result.stderr(), containsString(hudson.model.Messages.Hudson_TrailingDot()));
-        assertThat(result, failedWith(1));
+        assertThat(result, failedWith(8));
 
         assertThat(j.jenkins.getItems(), Matchers.hasSize(1));
     }

--- a/test/src/test/java/hudson/cli/CreateJobCommandTest.java
+++ b/test/src/test/java/hudson/cli/CreateJobCommandTest.java
@@ -81,7 +81,7 @@ class CreateJobCommandTest {
 
         CLICommandInvoker.Result result = invoker.withStdin(new ByteArrayInputStream("<project/>".getBytes(StandardCharsets.UTF_8))).invokeWithArgs("job1.");
         assertThat(result.stderr(), containsString(hudson.model.Messages.Hudson_TrailingDot()));
-        assertThat(result, failedWith(1));
+        assertThat(result, failedWith(8));
 
         assertThat(r.jenkins.getItems(), Matchers.hasSize(0));
     }
@@ -97,7 +97,7 @@ class CreateJobCommandTest {
 
         CLICommandInvoker.Result result = invoker.withStdin(new ByteArrayInputStream("<project/>".getBytes(StandardCharsets.UTF_8))).invokeWithArgs("job1.");
         assertThat(result.stderr(), containsString(hudson.model.Messages.Hudson_TrailingDot()));
-        assertThat(result, failedWith(1));
+        assertThat(result, failedWith(8));
 
         assertThat(r.jenkins.getItems(), Matchers.hasSize(1));
     }

--- a/test/src/test/java/hudson/cli/CreateNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/CreateNodeCommandTest.java
@@ -172,7 +172,7 @@ class CreateNodeCommandTest {
 
         assertThat(result.stderr(), containsString(Messages.Hudson_UnsafeChar('/')));
         assertThat(result, hasNoStandardOutput());
-        assertThat(result, failedWith(1));
+        assertThat(result, failedWith(8));
 
         // ensure not side effects
         assertEquals(nodeListSizeBefore, j.jenkins.getNodes().size());
@@ -190,7 +190,7 @@ class CreateNodeCommandTest {
 
         assertThat(result.stderr(), containsString(Messages.Hudson_TrailingDot()));
         assertThat(result, hasNoStandardOutput());
-        assertThat(result, failedWith(1));
+        assertThat(result, failedWith(8));
 
         // ensure not side effects
         assertEquals(nodeListSizeBefore, j.jenkins.getNodes().size());
@@ -211,7 +211,7 @@ class CreateNodeCommandTest {
 
         assertThat(result.stderr(), containsString(Messages.Hudson_TrailingDot()));
         assertThat(result, hasNoStandardOutput());
-        assertThat(result, failedWith(1));
+        assertThat(result, failedWith(8));
 
         // ensure not side effects
         assertEquals(nodeListSizeBefore + 1, j.jenkins.getNodes().size());

--- a/test/src/test/java/hudson/cli/UpdateNodeCommandTest.java
+++ b/test/src/test/java/hudson/cli/UpdateNodeCommandTest.java
@@ -143,7 +143,7 @@ class UpdateNodeCommandTest {
 
         assertThat(result.stderr(), containsString(Messages.Hudson_UnsafeChar('/')));
         assertThat(result, hasNoStandardOutput());
-        assertThat(result, failedWith(1));
+        assertThat(result, failedWith(8));
 
         assertEquals(okName, node.getNodeName());
         // ensure the other data were not saved

--- a/test/src/test/java/jenkins/security/Security4025Test.java
+++ b/test/src/test/java/jenkins/security/Security4025Test.java
@@ -118,7 +118,7 @@ class Security4025Test {
         byte[] payload = agentXmlNamed(VICTIM_AGENT, "/OVERWRITTEN").getBytes(StandardCharsets.UTF_8);
         CLICommandInvoker.Result result = command.withStdin(new ByteArrayInputStream(payload)).invokeWithArgs(SOURCE_AGENT);
 
-        assertThat(result, failedWith(1));
+        assertThat(result, failedWith(8));
         assertThat(result.stderr(), containsString("Node already exists: victim-agent"));
 
         assertNotNull(j.jenkins.getNode(SOURCE_AGENT));

--- a/test/src/test/java/jenkins/security/Security4025Test.java
+++ b/test/src/test/java/jenkins/security/Security4025Test.java
@@ -120,6 +120,7 @@ class Security4025Test {
 
         assertThat(result, failedWith(8));
         assertThat(result.stderr(), containsString("Node already exists: victim-agent"));
+        assertThat(result.stderr(), not(containsString("Unexpected exception occurred while performing")));
 
         assertNotNull(j.jenkins.getNode(SOURCE_AGENT));
 


### PR DESCRIPTION
Noticed during development of SECURITY-4025 when we were discussing the appropriate exception to throw. I chose `Failure` despite this poor behavior, since `Jenkins#checkGoodName` also throws that (as demonstrated in testing section below).

### Testing done

#### Before

```
%  java -jar jenkins-cli.jar -s http://localhost:8080/jenkins/ update-node a1 < ../agent-config.xml

ERROR: Unexpected exception occurred while performing update-node command.
hudson.model.Failure: ‘!’ is an unsafe character
	at jenkins.model.Jenkins.checkGoodName(Jenkins.java:4301)
	at jenkins.model.Nodes.replaceNode(Nodes.java:280)
	at hudson.model.Computer.updateByXml(Computer.java:1576)
	at hudson.cli.UpdateNodeCommand.run(UpdateNodeCommand.java:52)
	at hudson.cli.CLICommand.main(CLICommand.java:261)
	at hudson.cli.CLIAction$ServerSideImpl.run(CLIAction.java:360)
	at hudson.cli.CLIAction$2.lambda$opened$0(CLIAction.java:210)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

#### After

```
%  java -jar jenkins-cli.jar -s http://localhost:8080/jenkins/ update-node a1 < ../agent-config.xml 

ERROR: ‘!’ is an unsafe character
```

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- too minor

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label skip-changelog

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
