### PR TITLE
Add inline build step insertion for freestyle jobs

### DIFF
--- a/core/src/main/resources/lib/form/hetero-list.jelly
+++ b/core/src/main/resources/lib/form/hetero-list.jelly
@@ -78,6 +78,9 @@ THE SOFTWARE.
       If true the drag and drop will not be activated. This just removes the drag and
       drop UI, it will not prevent users from manually submitting a different order.
     </st:attribute>
+    <st:attribute name="enableInlineInsertion" type="java.lang.Boolean">
+        If true, shows extra insertion buttons above and between existing items.
+    </st:attribute>
   </st:documentation>
   <d:taglib uri="local">
     <d:tag name="body">
@@ -111,7 +114,7 @@ THE SOFTWARE.
   </d:taglib>
 
   <j:set var="targetType" value="${attrs.targetType?:it.class}"/>
-  <div class="jenkins-form-item hetero-list-container ${hasHeader?'with-drag-drop':''} ${attrs.oneEach?'one-each':''} ${attrs.honorOrder?'honor-order':''}">
+  <div class="jenkins-form-item hetero-list-container ${hasHeader?'with-drag-drop':''} ${attrs.oneEach?'one-each':''} ${attrs.honorOrder?'honor-order':''} ${attrs.enableInlineInsertion?'with-inline-insertion':''}">
     <!-- display existing items -->
     <j:forEach var="i" items="${attrs.items}"><!-- TODO consider customizedFields: how to distinguish default items from user-configured items? -->
       <j:set var="descriptor" value="${i.descriptor}" />

--- a/core/src/main/resources/lib/hudson/project/config-builders.jelly
+++ b/core/src/main/resources/lib/hudson/project/config-builders.jelly
@@ -33,6 +33,7 @@ THE SOFTWARE.
     <f:hetero-list name="builder" hasHeader="true"
                    descriptors="${h.getBuilderDescriptors(it)}"
                    items="${it.builders}"
+                   enableInlineInsertion="true"
                    addCaption="${%Add build step}"/>
   </f:section>
 </j:jelly>

--- a/src/main/js/components/dropdowns/hetero-list.js
+++ b/src/main/js/components/dropdowns/hetero-list.js
@@ -4,10 +4,33 @@ import Utils from "@/components/dropdowns/utils";
 import * as Symbols from "@/util/symbols";
 import { createElementFromHtml } from "@/util/dom";
 import tippy from "tippy.js";
+import { attach } from "jsdom/lib/jsdom/living/helpers/svg/basic-types";
 
 function init() {
   generateButtons();
   generateHandles();
+}
+
+function createAddButton(label, options = {}) {
+  const button = document.createElement("button");
+  button.setAttribute("type", "button");
+  button.classList.add("hetero-list-add", "jenkins-button");
+
+  if (options.inline) {
+    button.classList.add("hetero-list-add--inline", "jenkins-button--tertiary");
+    button.setAttribute("tooltip", label);
+    button.setAttribute("aria-label", label);
+    button.appendChild(createElementFromHtml(Symbols.PLUS));
+  } else {
+    button.appendChild(createElementFromHtml(Symbols.PLUS));
+    button.appendChild(document.createTextNode(label));
+  }
+
+  if (options.suffix) {
+    button.setAttribute("suffix", options.suffix);
+  }
+
+  return button;
 }
 
 function generateHandles() {
@@ -24,15 +47,9 @@ function generateHandles() {
 function convertInputsToButtons(e) {
   let oldInputs = e.querySelectorAll("INPUT.hetero-list-add");
   oldInputs.forEach((oldbtn) => {
-    let btn = document.createElement("button");
-    btn.setAttribute("type", "button");
-    btn.classList.add("hetero-list-add", "jenkins-button");
-    let plus = createElementFromHtml(Symbols.PLUS);
-    btn.appendChild(plus);
-    btn.appendChild(document.createTextNode(oldbtn.getAttribute("value")));
-    if (oldbtn.hasAttribute("suffix")) {
-      btn.setAttribute("suffix", oldbtn.getAttribute("suffix"));
-    }
+    let btn = createAddButton(oldbtn.getAttribute("value"), {
+      suffix: oldbtn.getAttribute("suffix"),
+    });
     oldbtn.parentNode.appendChild(btn);
     oldbtn.remove();
   });
@@ -52,30 +69,111 @@ function generateButtons() {
       let btn = Array.from(e.querySelectorAll("BUTTON.hetero-list-add")).pop();
 
       let prototypes = e.lastElementChild;
-      while (!prototypes.classList.contains("prototypes")) {
+      while (prototypes && !prototypes.classList?.contains("prototypes")) {
         prototypes = prototypes.previousElementSibling;
+      }
+      if (!prototypes) {
+        return;
       }
       let insertionPoint = prototypes.previousElementSibling; // this is where the new item is inserted.
 
       let templates = [];
-      let children = prototypes.children;
-      for (let i = 0; i < children.length; i++) {
-        let n = children[i];
-        let name = n.getAttribute("name");
-        let descriptorId = n.getAttribute("descriptorId");
-        let title = n.getAttribute("title");
+      for (let i = 0; i < prototypes.children.length; i++) {
+        let n = prototypes.children[i];
 
         templates.push({
           html: n.innerHTML,
-          name: name,
-          descriptorId: descriptorId,
-          title: title,
+          name: n.getAttribute("name"),
+          descriptorId: n.getAttribute("descriptorId"),
+          title: n.getAttribute("title"),
         });
       }
       prototypes.remove();
       let withDragDrop = registerSortableDragDrop(e);
+      const inlineInsertionEnabled = e.classList.contains("with-inline-insertion");
+      const honorOrder = e.classList.contains("honor-order");
+      const oneEach = e.classList.contains("one-each");
 
-      function insert(instance, template) {
+      // Rebuild inline insertion controls (+ buttons between items)
+      const rebuildInlineInsertionControls = () => {
+        e.querySelectorAll(".hetero-list-inline-insert").forEach((n) =>
+          n.remove(),
+        );
+
+        if (!inlineInsertionEnabled) {
+          return;
+        }
+
+        const items = Array.from(e.children).filter((c) =>
+          c.matches("DIV.repeated-chunk"),
+        );
+
+        if (items.length === 0) {
+          return;
+        }
+
+        items.forEach((item) => {
+          const wrapper = document.createElement("div");
+          wrapper.className = "hetero-list-inline-insert";
+          wrapper.setAttribute("aria-hidden", "true");
+          const inlineButton = createAddButton(btn.textContent.trim(), {
+            suffix: btn.getAttribute("suffix"),
+            inline: true,
+          });
+          wrapper.appendChild(inlineButton);
+          wrapper.referenceNode = item;
+          e.insertBefore(wrapper, item);
+          attachAddDropdown(inlineButton);
+        });
+      };
+
+      function getCurrentItems() {
+        return Array.from(e.children).filter((child) =>
+          child.matches("DIV.repeated-chunk"),
+        );
+      }
+
+      function findInsertionPointForTemplate(template) {
+        if (!template) {
+          return insertionPoint;
+        }
+
+        function descriptorOrder(did) {
+          if (did instanceof Element) {
+            did = did.getAttribute("descriptorId");
+          }
+          for (let i =0; i < templates.lngth; i++) {
+            if (templates[i].descriptorId == did) {
+              return i;
+            }
+          }
+          return 0;
+        }
+
+        const current = getCurrentItems();
+        let bestScore = -1;
+        let bestPos = 0;
+        for (let pos = 0; i < current.length ; pos++) {
+          let count = 0;
+          for (let i = 0 ; i < current.length ; i++) {
+            if ( (i < pos) === (descriptorOrder(current[i]) <= descriptorOrder(template.descriptorId))) {
+              count++;
+            }
+          }
+
+          if (bestScore <= count) {
+            bestScore = count;
+            bestPos = pos;
+          }
+        }
+
+        if (bestPos < current.length) {
+          return current[bestPos];
+        }
+        return insertionPoint;
+      }
+      // Insert new item at specified position
+      const insert = (instance, template, referenceNode) => {
         let nc = document.createElement("div");
         nc.className = "repeated-chunk fade-in";
         nc.setAttribute("name", template.name);
@@ -87,132 +185,74 @@ function generateButtons() {
         renderOnDemand(
           nc.querySelector("div.config-page"),
           function () {
-            function findInsertionPoint() {
-              // given the element to be inserted 'prospect',
-              // and the array of existing items 'current',
-              // and preferred ordering function, return the position in the array
-              // the prospect should be inserted.
-              // (for example 0 if it should be the first item)
-              function findBestPosition(prospect, current, order) {
-                function desirability(pos) {
-                  let count = 0;
-                  for (let i = 0; i < current.length; i++) {
-                    if (i < pos == order(current[i]) <= order(prospect)) {
-                      count++;
-                    }
-                  }
-                  return count;
-                }
+            let targetRef = referenceNode || insertionPoint;
 
-                let bestScore = -1;
-                let bestPos = 0;
-                for (let i = 0; i <= current.length; i++) {
-                  let d = desirability(i);
-                  if (bestScore <= d) {
-                    // prefer to insert them toward the end
-                    bestScore = d;
-                    bestPos = i;
-                  }
-                }
-                return bestPos;
-              }
-
-              let current = Array.from(e.children).filter(function (e) {
-                return e.matches("DIV.repeated-chunk");
-              });
-
-              function o(did) {
-                if (did instanceof Element) {
-                  did = did.getAttribute("descriptorId");
-                }
-                for (let i = 0; i < templates.length; i++) {
-                  if (templates[i].descriptorId == did) {
-                    return i;
-                  }
-                }
-                return 0; // can't happen
-              }
-
-              let bestPos = findBestPosition(template.descriptorId, current, o);
-              if (bestPos < current.length) {
-                return current[bestPos];
-              } else {
-                return insertionPoint;
-              }
+            if (honorOrder && !referenceNode) {
+              targetRef = findInsertionPointForTemplate(template);
             }
-            let referenceNode = e.classList.contains("honor-order")
-              ? findInsertionPoint()
-              : insertionPoint;
-            referenceNode.parentNode.insertBefore(nc, referenceNode);
 
-            // Initialize drag & drop for this component
+            targetRef.parentNode.insertBefore(nc, targetRef);
+
             if (withDragDrop) {
               registerSortableDragDrop(nc);
             }
             Behaviour.applySubtree(nc, true);
+            rebuildInlineInsertionControls();
             ensureVisible(nc);
             layoutUpdateCallback.call();
           },
           true,
         );
-      }
-
-      function has(id) {
-        return (
-          e.querySelector('DIV.repeated-chunk[descriptorId="' + id + '"]') !=
-          null
-        );
-      }
-
-      let oneEach = e.classList.contains("one-each");
+      };
 
       /**
-       * Disable the Add button if there are no more items to add
+       * Toggle add button state
        */
-      function toggleButtonState() {
-        const templateCount = templates.length;
+      const toggleButtonState = () => {
         const selectedCount = Array.from(e.children).filter(
-          (e) =>
-            e.classList.contains("repeated-chunk") &&
-            !e.classList.contains("fade-out"),
+          (c) =>
+            c.classList.contains("repeated-chunk") &&
+            !c.classList.contains("fade-out"),
         ).length;
-
-        btn.disabled = oneEach && selectedCount >= templateCount;
+        btn.disabled = oneEach && selectedCount >= templates.length;
       }
-      const observer = new MutationObserver(() => {
-        toggleButtonState();
-      });
+
+      const observer = new MutationObserver(toggleButtonState);
       observer.observe(e, {
         childList: true,
         subtree: true,
         attributes: true,
         attributeFilter: ["class"],
       });
-      toggleButtonState();
 
-      generateDropDown(btn, (instance) => {
-        let menuItems = [];
-        for (let i = 0; i < templates.length; i++) {
-          let n = templates[i];
-          let disabled = oneEach && has(n.descriptorId);
-          let type = disabled ? "DISABLED" : "button";
-          let item = {
-            displayName: n.title,
+      toggleButtonState();
+      rebuildInlineInsertionControls();
+
+      function attachAddDropdown(button) {
+        generateDropDown(button, (instance) => {
+          const explicitReferenceNode = button.closest(".hetero-list-inline-insert",)?.referenceNode;
+
+        let menuItems = templates.map((template) => {
+          const has = e.querySelector(`DIV.repeated-chunk[descriptorId="${template.descriptorId}"]`);
+          return {
+            displayName: template.title,
             onClick: (event) => {
               event.preventDefault();
               event.stopPropagation();
-              insert(instance, n);
+              insert(instance, template, explicitReferenceNode);
             },
-            type: type,
+            type: oneEach && has ? "DISABLED" : "button",
           };
-          menuItems.push(item);
-        }
+        });
+
         const menuContainer = document.createElement("div");
         const menu = Utils.generateDropdownItems(menuItems, true);
         menuContainer.appendChild(createFilter(menu));
         menuContainer.appendChild(menu);
         instance.setContent(menuContainer);
-      });
+        })
+      }
+      attachAddDropdown(btn);
     },
   );
 }

--- a/src/main/scss/form/_reorderable-list.scss
+++ b/src/main/scss/form/_reorderable-list.scss
@@ -225,6 +225,39 @@ div.repeated-chunk {
   margin-bottom: 1rem;
 }
 
+.hetero-list-inline-insert {
+  display: flex;
+  justify-content: center;
+  margin: 0.5rem 0;
+}
+
+// Reveal the inline "+" when the gap or nearby steps are hovered
+.hetero-list-inline-insert:hover .hetero-list-add--inline,
+.hetero-list-inline-insert:focus-within .hetero-list-add--inline,
+.repeated-chunk:hover + .hetero-list-inline-insert .hetero-list-add--inline,
+.repeated-chunk:hover ~ .hetero-list-inline-insert .hetero-list-add--inline {
+    opacity: 0.75;
+}
+
+.hetero-list-add--inline {
+  min-width: 2rem;
+  min-height: 2rem;
+  padding: 0;
+  border-radius: 999px;
+  opacity: 0;
+  transition: opacity var(--standard-transition);
+
+  svg {
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+
+  &:hover,
+  &:focus-visible {
+    opacity: 1;
+  }
+}
+
 .repeated-chunk + .repeatable-insertion-point + span .hetero-list-add,
 .repeated-chunk + .repeatable-insertion-point + .repeatable-add {
   margin-top: 1rem;

--- a/test/src/test/java/lib/form/HeteroListTest.java
+++ b/test/src/test/java/lib/form/HeteroListTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -87,6 +88,49 @@ class HeteroListTest {
         HTMLButtonElement menuItem = (HTMLButtonElement) result;
         String menuItemContent = menuItem.getInnerHTML();
         assertThat(menuItemContent, not(containsString("<img")));
+    }
+
+    @Test
+    void inlineInsertionControlsAppearForExistingItems() throws Exception {
+        JenkinsRule.WebClient wc = j.createWebClient();
+
+        RootActionImpl rootAction = ExtensionList.lookupSingleton(RootActionImpl.class);
+        TestItemDescribable.DynamicDisplayNameDescriptor first = ExtensionList.lookupSingleton(TestItemDescribable.DynamicDisplayNameDescriptor.class);
+        AnotherTestItemDescribable.DescriptorImpl second = ExtensionList.lookupSingleton(AnotherTestItemDescribable.DescriptorImpl.class);
+        rootAction.descriptorList = List.of(first, second);
+        rootAction.items = List.of(new TestItemDescribable(), new AnotherTestItemDescribable());
+
+        HtmlPage page = wc.goTo("root");
+
+        Object result = page.executeJavaScript("document.querySelectorAll('.hetero-list-inline-insert button.hetero-list-add').length").getJavaScriptResult();
+        assertThat(result, instanceOf(Number.class));
+        assertEquals(2, ((Number) result).intValue());
+    }
+
+    @Test
+    void inlineInsertionAddsNewItemBeforeReferencedBuildStep() throws Exception {
+        JenkinsRule.WebClient wc = j.createWebClient();
+
+        RootActionImpl rootAction = ExtensionList.lookupSingleton(RootActionImpl.class);
+        TestItemDescribable.DynamicDisplayNameDescriptor first = ExtensionList.lookupSingleton(TestItemDescribable.DynamicDisplayNameDescriptor.class);
+        AnotherTestItemDescribable.DescriptorImpl second = ExtensionList.lookupSingleton(AnotherTestItemDescribable.DescriptorImpl.class);
+        rootAction.descriptorList = List.of(first, second);
+        rootAction.items = List.of(new TestItemDescribable(), new AnotherTestItemDescribable());
+
+        HtmlPage page = wc.goTo("root");
+
+        page.executeJavaScript("document.querySelector('.hetero-list-inline-insert .hetero-list-add').click();");
+        page.executeJavaScript(
+                "Array.from(document.querySelectorAll('.jenkins-dropdown__item')).find(button => button.textContent.includes('Another')).click();"
+        );
+
+        Object result = page.executeJavaScript(
+                "Array.from(document.querySelectorAll('.repeated-chunk__header')).map(e => e.textContent.trim())"
+        ).getJavaScriptResult();
+        assertThat(result, instanceOf(List.class));
+        @SuppressWarnings("unchecked")
+        List<String> headers = (List<String>) result;
+        assertEquals(List.of("Another item", "NotYetDefined", "Another item"), headers);
     }
 
     @Test
@@ -202,9 +246,26 @@ class HeteroListTest {
         }
     }
 
+    public static class AnotherTestItemDescribable implements Describable<AnotherTestItemDescribable> {
+        @Override
+        public Descriptor<AnotherTestItemDescribable> getDescriptor() {
+            return ExtensionList.lookupSingleton(DescriptorImpl.class);
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends Descriptor<AnotherTestItemDescribable> {
+            @NonNull
+            @Override
+            public String getDisplayName() {
+                return "Another item";
+            }
+        }
+    }
+
     @TestExtension
     public static class RootActionImpl implements UnprotectedRootAction {
         public List<Descriptor<?>> descriptorList;
+        public List<Object> items = List.of();
 
         @Override
         @CheckForNull

--- a/test/src/test/resources/lib/form/HeteroListTest/RootActionImpl/index.jelly
+++ b/test/src/test/resources/lib/form/HeteroListTest/RootActionImpl/index.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
 <l:layout title="Testing the effect of validateButton">
   <l:main-panel>
-    <f:hetero-list name="no-care" descriptors="${it.descriptorList}"/>
+    <f:hetero-list name="no-care" descriptors="${it.descriptorList}" items="${it.items}" enableInlineInertion="true"/>
   </l:main-panel>
 </l:layout>
 </j:jelly>


### PR DESCRIPTION
<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.
-->

Fixes #16687 

This change adds inline insertion controls for freestyle job build steps so users can insert new step at top or between existing teps without dragging from the bottom add button.

What changed
- Enabled inline insertion in the freestyle build step hetero-list
- Added reusable inline + controls between build steps
- Kept the existing bottom "Add build step" button working
- Added hover-reveal styling for the inline controls
- Added UI coverage for inline insertion behaviour

Note: The change is scoped to freestyle build steps only. Existing repeatable list behaviour and ordering remain unchanged.

### Testing done

Verified inline build step insertion works in freestyle jobs, including top and middle insertion, with existing bottom add behaiour preserved.

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- human-readable text

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label enhancement,developer

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A

<!-- Comment:
Leave the proposed upgrade guidelines in the pull request with the "N/A" value if no upgrade guidelines are needed.
The changelog generator relies on the presence of the upgrade guidelines section as part of its data extraction process.
-->

### Submitter checklist

- [ ] The issue, if it exists, is well-described.
- [ ] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [ ] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/core-pr-reviewers.
-->

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
