### PR TITLE
Use locale-independent matching in build history search

### DIFF
--- a/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
+++ b/core/src/main/java/jenkins/widgets/HistoryPageFilter.java
@@ -38,6 +38,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -355,7 +356,7 @@ public class HistoryPageFilter<T> {
             return data.toString().equals(searchString);
         } else {
             if (UserSearchProperty.isCaseInsensitive()) {
-                return data.toString().toLowerCase().contains(searchString.toLowerCase());
+                return data.toString().toLowerCase(Locale.ROOT).contains(searchString.toLowerCase(Locale.ROOT));
             } else {
                 return data.toString().contains(searchString);
             }

--- a/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
+++ b/core/src/test/java/jenkins/widgets/HistoryPageFilterTest.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -342,6 +343,18 @@ class HistoryPageFilterTest {
     void should_lower_case_search_string_in_case_insensitive_search() throws IOException {
         Iterable<ModelObject> runs = Arrays.asList(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
         assertOneMatchingBuildForGivenSearchStringAndRunItems("FAILure", runs);
+    }
+
+    @Test
+    void should_be_case_insensitive_independent_of_default_locale() throws IOException {
+        Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr"));
+            Iterable<ModelObject> runs = Arrays.asList(new MockRun(2, Result.FAILURE), new MockRun(1, Result.SUCCESS));
+            assertOneMatchingBuildForGivenSearchStringAndRunItems("failure", runs);
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
     }
 
     @Test


### PR DESCRIPTION
Related to #25908

### Testing done

Added a regression test that sets the default Locale to Turkish and verifies that case-insensitive build history search still matches `Result.FAILURE` with the search string `failure`.

The test restores the original default Locale in a `finally` block.

Not run locally because this environment does not have a usable JRE or Maven installation.

Recommended command:

mvn --no-transfer-progress -f core/pom.xml \
  -Dtest=jenkins.widgets.HistoryPageFilterTest test

### Screenshots (UI changes only)

Not applicable.

#### Before

#### After

### Proposed changelog entries

- Use matching in build history search that is independent of locale.

### Proposed changelog category

/label bug

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of Content Security Policy Plugin (CSP).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [x] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [x] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title.
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.