### PR TITLE
Restore iconOnly summary link behavior

### DIFF
--- a/core/src/main/resources/lib/hudson/summary.jelly
+++ b/core/src/main/resources/lib/hudson/summary.jelly
@@ -46,7 +46,16 @@ THE SOFTWARE.
     <j:if test="${attrs.icon!=null}">
       <tr class="app-summary">
         <td>
-          <l:icon src="${icon}" />
+          <j:choose>
+            <j:when test="${attrs.href!=null}">
+              <a href="${attrs.href}">
+                <l:icon src="${icon}" />
+              </a>
+            </j:when>
+            <j:otherwise>
+              <l:icon src="${icon}" />
+            </j:otherwise>
+          </j:choose>
         </td>
         <td style="vertical-align:middle">
           <j:choose>

--- a/test/src/test/java/lib/hudson/SummaryTest.java
+++ b/test/src/test/java/lib/hudson/SummaryTest.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, Jenkins project contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package lib.hudson;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+import hudson.model.InvisibleAction;
+import hudson.model.RootAction;
+import org.htmlunit.html.DomNodeList;
+import org.htmlunit.html.HtmlElement;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class SummaryTest {
+
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+    }
+
+    @Test
+    void iconOnlyLinksIconButNotBody() throws Exception {
+        HtmlPage page = j.createWebClient().goTo("summary");
+
+        HtmlElement summary = page.getHtmlElementById("icon-only-summary");
+        DomNodeList<HtmlElement> anchors = summary.getElementsByTagName("a");
+        assertThat(anchors.size(), is(1));
+        assertThat(anchors.get(0).getAttribute("href"), is("target"));
+        assertThat(anchors.get(0).getElementsByTagName("svg").getFirst(), notNullValue());
+        assertThat(anchors.get(0).getTextContent(), not(containsString("Icon-only body")));
+        assertThat(summary.getTextContent(), containsString("Icon-only body"));
+    }
+
+    @Test
+    void hrefLinksIconAndBodyByDefault() throws Exception {
+        HtmlPage page = j.createWebClient().goTo("summary");
+
+        HtmlElement summary = page.getHtmlElementById("default-summary");
+        DomNodeList<HtmlElement> anchors = summary.getElementsByTagName("a");
+        assertThat(anchors.size(), is(2));
+        assertThat(anchors.get(0).getAttribute("href"), is("target"));
+        assertThat(anchors.get(0).getElementsByTagName("svg").getFirst(), notNullValue());
+        assertThat(anchors.get(1).getAttribute("href"), is("target"));
+        assertThat(anchors.get(1).getTextContent(), containsString("Default body"));
+    }
+
+    @Test
+    void withoutHrefDoesNotLinkIconOrBody() throws Exception {
+        HtmlPage page = j.createWebClient().goTo("summary");
+
+        HtmlElement summary = page.getHtmlElementById("no-href-summary");
+        assertThat(summary.getElementsByTagName("a").size(), is(0));
+        assertThat(summary.getTextContent(), containsString("No href body"));
+    }
+
+    @TestExtension
+    public static class TestRootAction extends InvisibleAction implements RootAction {
+
+        @Override
+        public String getUrlName() {
+            return "summary";
+        }
+    }
+}

--- a/test/src/test/resources/lib/hudson/SummaryTest/TestRootAction/index.jelly
+++ b/test/src/test/resources/lib/hudson/SummaryTest/TestRootAction/index.jelly
@@ -1,0 +1,48 @@
+<!--
+The MIT License
+
+Copyright (c) 2026, Jenkins project contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
+<l:layout title="">
+  <l:main-panel>
+    <table id="icon-only-summary">
+      <t:summary icon="symbol-search" href="target" iconOnly="true">
+        Icon-only body
+      </t:summary>
+    </table>
+
+    <table id="default-summary">
+      <t:summary icon="symbol-search" href="target">
+        Default body
+      </t:summary>
+    </table>
+
+    <table id="no-href-summary">
+      <t:summary icon="symbol-search">
+        No href body
+      </t:summary>
+    </table>
+  </l:main-panel>
+</l:layout>
+</j:jelly>


### PR DESCRIPTION
Fixes #16724

Restores the documented `iconOnly=true` behavior for `lib/hudson/summary.jelly` while preserving the default `href` behavior.

### Testing done

- `mvn -pl test -Dtest=lib.hudson.SummaryTest test -U` with JDK 25 (3 passed)

### Screenshots (UI changes only)

#### Before

N/A. The rendered summary icon and text are visually unchanged; the bug is the clickable target.

#### After

N/A. `iconOnly=true` now renders one link around the icon and leaves the body unlinked; this is covered by `SummaryTest`.

### Proposed changelog entries

- Restore `iconOnly` summary link behavior for hyperlinks on the icon (regression in 2.340).

### Proposed changelog category

/label regression-fix, web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [x] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [x] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

N/A

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
