### PR TITLE
Backporting for LTS 2.580.1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -56,7 +56,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-bom</artifactId>
-        <version>2.0.18</version>
+        <version>2.0.19</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
     <commons-fileupload2.version>2.0.0-M5</commons-fileupload2.version>
     <groovy.version>2.4.21</groovy.version>
     <jelly.version>1.1-jenkins-20260418</jelly.version>
-    <stapler.version>2117.vb_66952503166</stapler.version>
+    <stapler.version>2119.v8544a_3749d39</stapler.version>
   </properties>
 
   <dependencyManagement>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -164,7 +164,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
-        <version>1.10.17</version>
+        <version>1.10.18</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -122,6 +122,11 @@ THE SOFTWARE.
         <version>2.22.0</version>
       </dependency>
       <dependency>
+        <groupId>commons-lang</groupId>
+        <artifactId>commons-lang</artifactId>
+        <version>2.6</version>
+      </dependency>
+      <dependency>
         <groupId>jakarta.servlet</groupId>
         <artifactId>jakarta.servlet-api</artifactId>
         <version>5.0.0</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -161,6 +161,11 @@ THE SOFTWARE.
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
+      <!-- Jenkins doesn't use this directly, but some plugins wanted to use the latest -->
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins.tools</groupId>
       <artifactId>bridge-method-annotation</artifactId>
       <version>${bridge-method-injector.version}</version>

--- a/core/src/main/java/hudson/Util.java
+++ b/core/src/main/java/hudson/Util.java
@@ -96,12 +96,14 @@ import java.util.Date;
 import java.util.EnumSet;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.SimpleTimeZone;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -119,6 +121,7 @@ import jenkins.util.MemoryReductionUtil;
 import jenkins.util.SystemProperties;
 import jenkins.util.io.PathRemover;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.time.FastDateFormat;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Copy;
@@ -1932,8 +1935,22 @@ public class Util {
                 "<!--%n", Functions.htmlAttributeEscape(redirectUrl), message);
     }
 
+    /**
+     * @deprecated use {@link #XS_DATETIME_FORMATTER2}
+     */
+    @Deprecated
+    public static final FastDateFormat XS_DATETIME_FORMATTER = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss'Z'", new SimpleTimeZone(0, "GMT"));
+
     public static final DateTimeFormatter XS_DATETIME_FORMATTER2 =
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
+
+    // Note: RFC822 dates must not be localized!
+    /**
+     * @deprecated use {@link DateTimeFormatter#RFC_1123_DATE_TIME}
+     */
+    @Deprecated
+    public static final FastDateFormat RFC822_DATETIME_FORMATTER
+            = FastDateFormat.getInstance("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US);
 
     private static final Logger LOGGER = Logger.getLogger(Util.class.getName());
 

--- a/core/src/main/java/jenkins/security/csp/impl/CspDecorator.java
+++ b/core/src/main/java/jenkins/security/csp/impl/CspDecorator.java
@@ -37,6 +37,7 @@ import jenkins.security.csp.CspBuilder;
 import jenkins.security.csp.CspHeader;
 import jenkins.security.csp.CspHeaderDecider;
 import jenkins.security.csp.ReportingContext;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Ancestor;
@@ -73,10 +74,7 @@ public class CspDecorator extends PageDecorator {
     @CheckForNull
     /* package */ static String getReportingEndpoint(HttpServletRequest req) {
         Class<?> modelObjectClass = null;
-        String restOfPath = req.getRequestURI();
-        if (restOfPath.startsWith(req.getContextPath())) {
-            restOfPath = restOfPath.substring(req.getContextPath().length());
-        }
+        String restOfPath = StringUtils.removeStart(req.getRequestURI(), req.getContextPath());
         final StaplerRequest2 staplerRequest2 = Stapler.getCurrentRequest2();
         if (staplerRequest2 != null) {
             final List<Ancestor> ancestors = staplerRequest2.getAncestors();

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@ THE SOFTWARE.
     <!-- Skips node installation, "yarn install" and "yarn build". Only safe when
          war/src/main/webapp/jsbundles is already populated from an earlier build. -->
     <skip.frontend>false</skip.frontend>
-    <winstone.version>8.1047.v331d3186f463</winstone.version>
+    <winstone.version>8.1050.veb_a_0d2124285</winstone.version>
     <node.version>24.19.0</node.version>
   </properties>
 


### PR DESCRIPTION
## Backporting for LTS 2.580.1

Part of the Jenkins 2.580.1 LTS release checklist:

* https://github.com/jenkins-infra/release/issues/964

Includes backports of issues:

* https://github.com/jenkinsci/jenkins/issues/27351

That issue requests a backport to revert pull request:

* https://github.com/jenkinsci/jenkins/pull/26105

Includes cherry pick of pull requests:

* https://github.com/jenkinsci/jenkins/pull/27354
* https://github.com/jenkinsci/jenkins/pull/27341
* https://github.com/jenkinsci/jenkins/pull/27357
* https://github.com/jenkinsci/jenkins/pull/27362

I consider those 3 pull request backports as "open for discussion".  I've included them in the pull request as a way to provide a location for discussion.

The backport of Apache Ant 1.10.18 is intended to reduce the noise from software content analysis tools that will complain about the vulnerability reported in Apache Ant 1.10.17 and earlier.  The [security issue](https://ant.apache.org/security.html) (Path traversal in ftp and scp tasks allows arbitrary file write [CVE-2026-78254](https://www.cve.org/CVERecord?id=CVE-2026-78254).) only affects the ftp and scp tasks.  Those tasks are only affected under very specific conditions.  It is unlikely to affect Jenkins, but will cause complaints from software composition analysis tools.

The backport of winstone 8.1050 is intended to use the most recent release (12.1.13) of Eclipse Jetty.  That version of Eclipse Jetty is included in Jenkins 2.581 on September 8, 2026.  We have updated Jetty versions in LTS lines in the past in order to assure that the LTS is running the most recent version.

The backport of slf4j is used to keep the slf4j version consistent between Jenkins core and winstone.  Winstone 8.1050 includes slf4j 2.0.19.

The backport of Stapler is intended to use the most recent release (12.1.13) of Eclipse Jetty.  It will be included in Jenkins 2.582 September 15, 2026.

I am willing to remove any or all of the cherry picked pull requests, based on guidance from others in the Jenkins project.  I'd specifically like input from the @timja, @jglick, and @daniel-beck.

I will be away from home next week, so I need to complete the delivery of the 2.580.1 release candidate by the end of the day September 12, 2026.

<!-- Comment:
!!! ⚠️ IMPORTANT ⚠️ !!!
Do not remove any of the sections below, even if they are not applicable to your change. The sections are used by the
changelog generator and other tools to extract information about the change. If a section is not applicable,
leave as is. Carefully read the instructions in each section and provide the necessary information.

Pull requests that do not follow the template might be closed without further review.
-->

<!-- Comment:
A great PR typically begins with the line below.
Replace <issue-number> with the issue number.

Fixes #<issue-number>
-->

<!-- Comment:
If the issue is not fully described in the issue tracker, add more information here (justification, pull request links, etc.).

 * We do not require an issue for minor improvements.
 * Major new features should have an issue created.
-->

### Testing done

* Ran the controller with the vstestrunner plugin on Jenkins 2.581 and confirmed the issue is visible
* Ran the controller with the vstestrunner plugin on this pull request and confirmed the issue is not visible
* Ran all core tests successfully on my local Linux computer

### Screenshots (UI changes only)

<!--
If your change involves a UI change, please include screenshots showing the before and after states.
-->

#### Before

#### After

### Proposed changelog entries

- N/A

<!-- Comment:
The changelog entry should be in the imperative mood; e.g., write "do this"/"return that" rather than "does this"/"returns that".
For examples, see: https://www.jenkins.io/changelog/

Do not include the issue in the changelog entry.
Include the issue in the description of the pull request so that the changelog generator can find it and include it in the generated changelog.

You may add multiple changelog entries if applicable by adding a new entry to the list, e.g.
- First changelog entry
- Second changelog entry
-->

### Proposed changelog category

/label into-lts

<!--
The changelog entry needs to have a category which is selected based on the label.
If there's no changelog then the label should be `skip-changelog`.

The available categories are:
* bug - Minor bug. Will be listed after features
* developer - Changes which impact plugin developers
* dependencies - Pull requests that update a dependency
* internal - Internal only change, not user facing
* into-lts - Changes that are backported to the LTS baseline
* localization - Updates localization files
* major-bug - Major bug. Will be highlighted on the top of the changelog
* major-rfe - Major enhancement. Will be highlighted on the top
* rfe - Minor enhancement
* regression-fix - Fixes a regression in one of the previous Jenkins releases
* removed - Removes a feature or a public API
* skip-changelog - Should not be shown in the changelog

Non-changelog categories:
* web-ui - Changes in the web UI

Non-changelog categories require a changelog category but should be used if applicable,
comma separate to provide multiple categories in the label command.
-->

### Proposed upgrade guidelines

N/A because no upgrade guidelines are needed.

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developers, depending on the change) and are in the imperative mood (see [examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)). Fill in the **Proposed upgrade guidelines** section only if there are breaking changes or changes that may require extra steps from users during upgrade.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [ ] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate.
- [ ] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable.
- [ ] UI changes do not introduce regressions when enforcing the current default rules of [Content Security Policy Plugin](https://plugins.jenkins.io/csp/). In particular, new or substantially changed JavaScript is not defined inline and does not call `eval` to ease future introduction of Content Security Policy (CSP) directives (see [documentation](https://www.jenkins.io/doc/developer/security/csp/)).
- [ ] For dependency updates, there are links to external changelogs and, if possible, full differentials.
- [ ] For new APIs and extension points, there is a link to at least one consumer.

### Desired reviewers

@timja, @jglick, @daniel-beck

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title (see [example](https://github.com/jenkinsci/jenkins/pull/4387)).
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.
