### PR TITLE
Fix OpenSearch XML content-type and add moz:SearchForm

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/opensearch.xml.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/opensearch.xml.jelly
@@ -27,14 +27,15 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-  <l:view contentType="application/xml;charset=UTF-8">
-  <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <l:view contentType="application/opensearchdescription+xml;charset=UTF-8">
+  <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
   <j:set var="rootURL" value="${h.inferHudsonURL(request2)}"/>
   <ShortName>Jenkins</ShortName>
   <Description>Jenkins at ${rootURL}</Description>
   <InputEncoding>UTF-8</InputEncoding>
   <Url type="text/html" method="GET" template="${rootURL}search/?q={searchTerms}" />
   <Url type="application/x-suggestions+json" template="${rootURL}search/suggestOpenSearch?q={searchTerms}"/>
+  <moz:SearchForm>${rootURL}</moz:SearchForm>
 </OpenSearchDescription>
   </l:view>
 </j:jelly>

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -501,4 +501,19 @@ public class SearchTest {
         assertNotNull(jsonArray);
         return jsonArray;
     }
+
+    @Issue("27210")
+    @Test
+    void testOpenSearchXml() throws Exception {
+        WebClient wc = j.createWebClient();
+        Page page = wc.goTo("opensearch.xml", "application/opensearchdescription+xml");
+        assertNotNull(page);
+        j.assertGoodStatus(page);
+
+        assertEquals("application/opensearchdescription+xml", page.getWebResponse().getContentType());
+
+        String content = page.getWebResponse().getContentAsString();
+        assertTrue(content.contains("xmlns:moz=\"http://www.mozilla.org/2006/browser/search/\""));
+        assertTrue(content.contains("<moz:SearchForm>"));
+    }
 }


### PR DESCRIPTION

Fixes #27210

## Summary
Updated Jenkins OpenSearch XML endpoint to comply with OpenSearch 1.1 specification and Mozilla browser requirements.

- Added Mozilla namespace: `xmlns:moz="http://www.mozilla.org/2006/browser/search/"`
- Added `<moz:SearchForm>` element linking search engine to Jenkins homepage
- Added unit test `SearchTest#testOpenSearchXml` with full validation

## Problem Solved
Before this fix:
- Browsers (Firefox, Chrome, Edge) rejected Jenkins OpenSearch descriptor due to incorrect MIME type
- OpenSearch 1.1 spec requires exact MIME type `application/opensearchdescription+xml`
- Mozilla extension (`<moz:SearchForm>`) was missing, preventing proper search engine integration


After this fix:
- Browsers accept Jenkins as a valid custom search engine
- Search engine properly links back to Jenkins homepage
- Complies with OpenSearch 1.1 and Mozilla extension specifications

## Testing
- Unit test `SearchTest#testOpenSearchXml` passes with BUILD SUCCESS
- Test validates:
  - HTTP 200 OK response
  - Correct Content-Type header: `application/opensearchdescription+xml`
  - Presence of Mozilla namespace in XML
  - Presence of `<moz:SearchForm>` tag
  
 