### PR TITLE
Fix OpenSearch XML content-type and add moz:SearchForm

### DIFF
--- a/core/src/main/resources/jenkins/model/Jenkins/opensearch.xml.jelly
+++ b/core/src/main/resources/jenkins/model/Jenkins/opensearch.xml.jelly
@@ -27,14 +27,15 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-  <l:view contentType="application/xml;charset=UTF-8">
-  <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <l:view contentType="application/opensearchdescription+xml;charset=UTF-8">
+  <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
   <j:set var="rootURL" value="${h.inferHudsonURL(request2)}"/>
   <ShortName>Jenkins</ShortName>
   <Description>Jenkins at ${rootURL}</Description>
   <InputEncoding>UTF-8</InputEncoding>
   <Url type="text/html" method="GET" template="${rootURL}search/?q={searchTerms}" />
   <Url type="application/x-suggestions+json" template="${rootURL}search/suggestOpenSearch?q={searchTerms}"/>
+  <moz:SearchForm>${rootURL}</moz:SearchForm>
 </OpenSearchDescription>
   </l:view>
 </j:jelly>

--- a/test/src/test/java/hudson/search/SearchTest.java
+++ b/test/src/test/java/hudson/search/SearchTest.java
@@ -501,4 +501,19 @@ public class SearchTest {
         assertNotNull(jsonArray);
         return jsonArray;
     }
+
+    @Issue("27210")
+    @Test
+    void testOpenSearchXml() throws Exception {
+        WebClient wc = j.createWebClient();
+        Page page = wc.goTo("opensearch.xml", "application/opensearchdescription+xml");
+        assertNotNull(page);
+        j.assertGoodStatus(page);
+
+        assertEquals("application/opensearchdescription+xml", page.getWebResponse().getContentType());
+
+        String content = page.getWebResponse().getContentAsString();
+        assertTrue(content.contains("xmlns:moz=\"http://www.mozilla.org/2006/browser/search/\""));
+        assertTrue(content.contains("<moz:SearchForm>"));
+    }
 }


### PR DESCRIPTION
### Proposed changelog entries

- Allow Jenkins to be added to Firefox using OpenSearch.

### Proposed changelog category
/label bug

### Description
Fixes #27210

Updated `opensearch.xml.jelly` to return the correct MIME type `application/opensearchdescription+xml` per OpenSearch 1.1 specification. Added Mozilla namespace (`xmlns:moz`) and `<moz:SearchForm>` element to properly link the search engine to Jenkins homepage.

**Changes made:**
- Changed `Content-Type` from `application/xml` to `application/opensearchdescription+xml` in `core/src/main/resources/jenkins/model/Jenkins/opensearch.xml.jelly`
- Added Mozilla namespace: `xmlns:moz="http://www.mozilla.org/2006/browser/search/"`
- Added `<moz:SearchForm>${rootURL}</moz:SearchForm>` element
- Added unit test `SearchTest#testOpenSearchXml` to validate the fix

**Why this fix is needed:**
Before this fix, Jenkins returned `Content-Type: application/xml`, causing browsers (Firefox, Chrome, Edge) to reject the OpenSearch descriptor because the OpenSearch 1.1 specification requires the exact MIME type `application/opensearchdescription+xml`. The Mozilla `<moz:SearchForm>` extension was also missing, preventing browsers from properly linking the search engine to the Jenkins homepage.

### Testing done
Added comprehensive unit test `SearchTest#testOpenSearchXml` that validates:
- HTTP 200 OK status response
- Correct Content-Type header: `application/opensearchdescription+xml`
- Presence of Mozilla namespace in XML output
- Presence of `<moz:SearchForm>` tag

Test passes with BUILD SUCCESS.

**Interactive testing in Firefox:**
Started Jenkins locally with `mvn -pl war hpi:run` and navigated to `http://localhost:8080/jenkins/opensearch.xml` in Firefox. Confirmed the XML response contains the correct `xmlns:moz` namespace and `<moz:SearchForm>` element. Firefox successfully recognizes Jenkins as a valid OpenSearch descriptor without any "Download Error", and search queries redirect correctly to the Jenkins search results page.

### Proposed upgrade guidelines
N/A

---

### Submitter checklist
- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change.
- [x] There is automated testing (unit test added).
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs. (N/A - no new public APIs)
- [x] New deprecations are annotated. (N/A - no deprecations)
- [x] UI changes do not introduce regressions when enforcing CSP rules. (N/A - backend XML change only)
- [x] For dependency updates, there are links to external changelogs. (N/A - no dependency updates)
- [x] For new APIs and extension points, there is a link to at least one consumer. (N/A - no new APIs)

---

### Maintainer checklist
- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change
- [x] Changelog entries in the pull request title and/or Proposed changelog entries are accurate, human-readable, and in the imperative mood
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- ~If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a Proposed upgrade guidelines section in the pull request title~
- ~If it would make sense to backport the change to LTS, a Jira issue must be filed with the `lts-candidate` label~



---