### PR TITLE
Reintroduce experimental page layout with scrolling regressions fixed

### DIFF
--- a/core/src/main/resources/hudson/PluginManager/available.jelly
+++ b/core/src/main/resources/hudson/PluginManager/available.jelly
@@ -69,9 +69,10 @@ THE SOFTWARE.
       <script src="${resURL}/jsbundles/plugin-manager-ui.js" type="text/javascript"/>
 
       <form id="form" method="post" action="install">
-        <table id="plugins" class="jenkins-table sortable"
-               data-hasAdmin="${h.hasPermission(app.ADMINISTER)}"
-               data-health="${app.updateCenter.healthScoresAvailable}">
+        <div class="jenkins-table-wrapper">
+          <table id="plugins" class="jenkins-table sortable"
+                 data-hasAdmin="${h.hasPermission(app.ADMINISTER)}"
+                 data-health="${app.updateCenter.healthScoresAvailable}">
           <thead>
             <tr>
               <l:isAdmin>
@@ -92,7 +93,8 @@ THE SOFTWARE.
             </tr>
           </thead>
           <tbody/>
-        </table>
+          </table>
+        </div>
       </form>
   </l:settings-subpage>
 </j:jelly>

--- a/core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -74,7 +74,8 @@ THE SOFTWARE.
           <l:notice icon="symbol-plugins" title="${%No plugins installed}" />
         </j:when>
         <j:otherwise>
-          <table id="plugins" class="jenkins-table sortable">
+          <div class="jenkins-table-wrapper">
+            <table id="plugins" class="jenkins-table sortable">
             <thead>
             <tr>
               <th initialSortDir="down">${%Name}</th>
@@ -296,7 +297,8 @@ THE SOFTWARE.
                 </tr>
               </j:forEach>
             </tbody>
-          </table>
+            </table>
+          </div>
         </j:otherwise>
       </j:choose>
 

--- a/core/src/main/resources/hudson/PluginManager/sidepanel.jelly
+++ b/core/src/main/resources/hudson/PluginManager/sidepanel.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-  <l:side-panel sticky="true">
+  <l:side-panel>
     <l:app-bar title="${%Plugins}" />
     <l:tasks>
       <l:task href="${rootURL}/manage/pluginManager/" icon="symbol-download" title="${%Updates}" badge="${app.updateCenter.badge}"/>

--- a/core/src/main/resources/hudson/PluginManager/updates.jelly
+++ b/core/src/main/resources/hudson/PluginManager/updates.jelly
@@ -59,7 +59,8 @@ THE SOFTWARE.
 
         <j:choose>
           <j:when test="${!empty(list)}">
-            <table id="plugins" class="jenkins-table sortable">
+            <div class="jenkins-table-wrapper">
+              <table id="plugins" class="jenkins-table sortable">
               <thead>
                 <tr>
                   <l:isAdmin>
@@ -244,7 +245,8 @@ THE SOFTWARE.
                       </j:if>
                     </tr>
                   </j:forEach>
-            </table>
+              </table>
+            </div>
           </j:when>
           <j:otherwise>
             <l:notice icon="symbol-up-to-date" title="${%No updates available}" />

--- a/core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -64,72 +64,74 @@ THE SOFTWARE.
     <j:set var="monitors" value="${it._monitors}"/>
     <j:set var="tableWidth" value="${3}"/>
     <t:setIconSize/>
-    <table id="computers" class="jenkins-table ${iconSize == '16x16' ? 'jenkins-table--small' : iconSize == '24x24' ? 'jenkins-table--medium' : ''} sortable">
-      <thead>
-        <tr>
-          <th class="jenkins-table__cell--tight">S</th>
-          <th initialSortDir="down">${%Name}</th>
-          <j:forEach var="m" items="${monitors}">
-            <j:if test="${m.columnCaption!=null}">
-              <j:set var="tableWidth" value="${tableWidth+1}"/>
-              <th align="right" tooltip="${m.descriptor.timestampString}">${m.columnCaption}</th>
-            </j:if>
-          </j:forEach>
-          <th class="jenkins-table__cell--tight" data-sort-disable="true" />
-        </tr>
-      </thead>
-      <tbody>
-      <j:getStatic var="extendedReadPermission" className="hudson.model.Computer" field="EXTENDED_READ"/>
-      <j:forEach var="c" items="${it.computers}">
-        <tr id="node_${c.name}">
-          <td data="${c.icon}" class="jenkins-table__cell--tight jenkins-table__icon">
-            <div class="jenkins-table__cell__button-wrapper">
-              <l:icon src="${c.iconClassName}" alt="${c.iconAltText}" tooltip="${c.tooltip}"/>
-            </div>
-          </td>
-
-          <td>
-            <a href="../${c.url}" class="jenkins-table__link model-link inside">${c.displayName}</a>
-          </td>
-
-          <j:forEach var="m" items="${monitors}">
-            <j:if test="${m.columnCaption!=null}">
-              <j:set var="data" value="${m.data(c)}"/>
-              <st:include page="column.jelly" from="${m}" />
-            </j:if>
-          </j:forEach>
-
-          <td class="jenkins-table__cell--tight">
-            <j:if test="${c.hasPermission(extendedReadPermission)}">
+    <div class="jenkins-table-wrapper">
+      <table id="computers" class="jenkins-table ${iconSize == '16x16' ? 'jenkins-table--small' : iconSize == '24x24' ? 'jenkins-table--medium' : ''} sortable">
+        <thead>
+          <tr>
+            <th class="jenkins-table__cell--tight">S</th>
+            <th initialSortDir="down">${%Name}</th>
+            <j:forEach var="m" items="${monitors}">
+              <j:if test="${m.columnCaption!=null}">
+                <j:set var="tableWidth" value="${tableWidth+1}"/>
+                <th align="right" tooltip="${m.descriptor.timestampString}">${m.columnCaption}</th>
+              </j:if>
+            </j:forEach>
+            <th class="jenkins-table__cell--tight" data-sort-disable="true" />
+          </tr>
+        </thead>
+        <tbody>
+        <j:getStatic var="extendedReadPermission" className="hudson.model.Computer" field="EXTENDED_READ"/>
+        <j:forEach var="c" items="${it.computers}">
+          <tr id="node_${c.name}">
+            <td data="${c.icon}" class="jenkins-table__cell--tight jenkins-table__icon">
               <div class="jenkins-table__cell__button-wrapper">
-                <a href="../${c.url}configure" class="jenkins-button jenkins-button--tertiary">
-                  <l:icon src="symbol-settings" />
-                </a>
+                <l:icon src="${c.iconClassName}" alt="${c.iconAltText}" tooltip="${c.tooltip}"/>
               </div>
-            </j:if>
-          </td>
-        </tr>
-      </j:forEach>
+            </td>
 
-      <!-- let clouds contribute fragments here -->
-      <j:forEach var="cloud" items="${app.clouds}">
-        <st:include it="${cloud}" page="computerSet.jelly" optional="true" />
-      </j:forEach>
+            <td>
+              <a href="../${c.url}" class="jenkins-table__link model-link inside">${c.displayName}</a>
+            </td>
 
-      <tr class="sortbottom">
-        <th />
-        <th>${%Data obtained}</th>
-        <j:forEach var="m" items="${monitors}">
-          <j:if test="${m.columnCaption!=null}">
-            <th align="right">
-              ${m.descriptor.timestampString}
-            </th>
-          </j:if>
+            <j:forEach var="m" items="${monitors}">
+              <j:if test="${m.columnCaption!=null}">
+                <j:set var="data" value="${m.data(c)}"/>
+                <st:include page="column.jelly" from="${m}" />
+              </j:if>
+            </j:forEach>
+
+            <td class="jenkins-table__cell--tight">
+              <j:if test="${c.hasPermission(extendedReadPermission)}">
+                <div class="jenkins-table__cell__button-wrapper">
+                  <a href="../${c.url}configure" class="jenkins-button jenkins-button--tertiary">
+                    <l:icon src="symbol-settings" />
+                  </a>
+                </div>
+              </j:if>
+            </td>
+          </tr>
         </j:forEach>
-        <th />
-      </tr>
-      </tbody>
-    </table>
+
+        <!-- let clouds contribute fragments here -->
+        <j:forEach var="cloud" items="${app.clouds}">
+          <st:include it="${cloud}" page="computerSet.jelly" optional="true" />
+        </j:forEach>
+
+        <tr class="sortbottom">
+          <th />
+          <th>${%Data obtained}</th>
+          <j:forEach var="m" items="${monitors}">
+            <j:if test="${m.columnCaption!=null}">
+              <th align="right">
+                ${m.descriptor.timestampString}
+              </th>
+            </j:if>
+          </j:forEach>
+          <th />
+        </tr>
+        </tbody>
+      </table>
+    </div>
     <t:iconSize>
       <div class="jenkins-buttons-row jenkins-buttons-row--invert">
         <button class="jenkins-button jenkins-button--tertiary" id="button-computer-icon-legend">

--- a/core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/core/src/main/resources/hudson/model/Job/configure.jelly
@@ -36,7 +36,7 @@ THE SOFTWARE.
 
     <l:breadcrumb title="${readOnlyMode ? '%Configuration' : '%Configure'}" />
 
-    <l:side-panel sticky="true">
+    <l:side-panel>
       <l:app-bar title="${readOnlyMode ? '%Configuration' : '%Configure'}" />
       <div id="tasks">
         <l:skeleton type="side-panel" />

--- a/core/src/main/resources/jenkins/views/JenkinsHeader/logo.jelly
+++ b/core/src/main/resources/jenkins/views/JenkinsHeader/logo.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-  <a href="${rootURL}/" class="app-jenkins-logo">
+  <a href="${rootURL}/" class="app-jenkins-logo" tooltip="Jenkins ${app.VERSION}" data-tooltip-delay="1000">
     <img id="jenkins-head-icon" src="${imagesURL}/svgs/logo.svg" aria-hidden="true" />
     <span class="jenkins-mobile-hide">Jenkins</span>
   </a>

--- a/core/src/main/resources/lib/hudson/progressive-text.js
+++ b/core/src/main/resources/lib/hudson/progressive-text.js
@@ -11,7 +11,9 @@ Behaviour.specify(
     let errorMessage = holder.getAttribute("data-error-message");
 
     var scroller = new AutoScroller(
-      holder.closest(".progressive-text-container") || document.body,
+      holder.closest(".progressive-text-container, #main-panel, #page-body") ||
+        document.scrollingElement ||
+        document.documentElement,
     );
     /*
   fetches the latest update from the server

--- a/core/src/main/resources/lib/hudson/progressive-text.js
+++ b/core/src/main/resources/lib/hudson/progressive-text.js
@@ -10,11 +10,26 @@ Behaviour.specify(
     let onFinishEvent = holder.getAttribute("data-on-finish-event");
     let errorMessage = holder.getAttribute("data-error-message");
 
-    var scroller = new AutoScroller(
-      holder.closest(".progressive-text-container, #main-panel, #page-body") ||
-        document.scrollingElement ||
-        document.documentElement,
-    );
+    // The scrolling element depends on the layout, so resolve it on demand.
+    function resolveScrollContainer() {
+      const container = holder.closest(".progressive-text-container");
+      if (container) {
+        return container;
+      }
+      for (let node = holder.parentElement; node; node = node.parentElement) {
+        const overflowY = getComputedStyle(node).overflowY;
+        if (
+          overflowY === "auto" ||
+          overflowY === "scroll" ||
+          overflowY === "overlay"
+        ) {
+          return node;
+        }
+      }
+      return document.scrollingElement || document.documentElement;
+    }
+
+    var scroller = new AutoScroller(resolveScrollContainer);
     /*
   fetches the latest update from the server
   @param e

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -169,12 +169,12 @@ THE SOFTWARE.
                     logout="${%logout}"/>
     </j:if>
 
-    <div id="page-body" class="app-page-body app-page-body--${layoutType} clear">
+    <div id="page-body" class="${layoutType eq 'full-screen' ? 'app-full-screen-page-body' : 'app-page-body'} clear">
       <j:if test="${layoutType=='two-column'}">
         <j:set var="mode" value="side-panel" />
         <d:invokeBody />
       </j:if>
-      <div id="main-panel">
+      <div class="app-page-body__contents">
         <j:set var="mode" value="main-panel" />
         <d:invokeBody/>
       </div>

--- a/core/src/main/resources/lib/layout/layout.jelly
+++ b/core/src/main/resources/lib/layout/layout.jelly
@@ -169,12 +169,13 @@ THE SOFTWARE.
                     logout="${%logout}"/>
     </j:if>
 
-    <div id="page-body" class="${layoutType eq 'full-screen' ? 'app-full-screen-page-body' : 'app-page-body'} clear">
+    <div id="page-body" class="${layoutType eq 'full-screen' ? 'app-full-screen-page-body' : 'app-page-body'} clear"
+         data-scroll-region-label="${%scrollRegion}">
       <j:if test="${layoutType=='two-column'}">
         <j:set var="mode" value="side-panel" />
         <d:invokeBody />
       </j:if>
-      <div class="app-page-body__contents">
+      <div class="app-page-body__contents" data-scroll-region-label="${%scrollRegion}">
         <j:set var="mode" value="main-panel" />
         <d:invokeBody/>
       </div>

--- a/core/src/main/resources/lib/layout/layout.properties
+++ b/core/src/main/resources/lib/layout/layout.properties
@@ -26,3 +26,4 @@ logout=log out
 title=Jenkins
 jenkinshead.alt=Jenkins
 search=Search
+scrollRegion=Page content

--- a/core/src/main/resources/lib/layout/main-panel.jelly
+++ b/core/src/main/resources/lib/layout/main-panel.jelly
@@ -26,40 +26,47 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
   <st:documentation>
     Generates the body as the main content part of a Jenkins page.
+    <st:attribute name="width">
+      Optional, sets the width of the page. Available options are 'default', 'narrow', or 'wide'.
+    </st:attribute>
   </st:documentation>
 
   <j:if test="${mode=='main-panel'}">
-    <j:if test="${app.isQuietingDown()}">
-      <j:choose>
-        <j:when test="${app.isPreparingSafeRestart()}">
-          <div id='safe-restart-msg'>
-            <j:choose>
-              <j:when test="${!app.getQuietDownReason().trim().isEmpty()}">
-                ${app.getQuietDownReason()}
-              </j:when>
-              <j:otherwise>
-                ${%saferestart}
-              </j:otherwise>
-            </j:choose>
-          </div>
-        </j:when>
-        <j:otherwise>
-          <div id='shutdown-msg'>
-            <j:choose>
-              <j:when test="${app.getQuietDownReason() != null}">
-                ${app.getQuietDownReason()}
-              </j:when>
-              <j:otherwise>
-                ${%shutdown}
-              </j:otherwise>
-            </j:choose>
-          </div>
-        </j:otherwise>
-      </j:choose>
-    </j:if>
-    <a id="skip2content" />
-    <x:comment>&#10;start of main content ⇒&#10;</x:comment>
-    <d:invokeBody />
-    <x:comment>&#10;⇐ end of main content&#10;</x:comment>
+    <div id="main-panel" class="app-main-panel
+              ${attrs.width eq 'wide' ? 'app-main-panel--wide' : ''}
+              ${attrs.width eq 'narrow' ? 'app-main-panel--narrow' : ''}">
+      <j:if test="${app.isQuietingDown()}">
+        <j:choose>
+          <j:when test="${app.isPreparingSafeRestart()}">
+            <div id='safe-restart-msg'>
+              <j:choose>
+                <j:when test="${!app.getQuietDownReason().trim().isEmpty()}">
+                  ${app.getQuietDownReason()}
+                </j:when>
+                <j:otherwise>
+                  ${%saferestart}
+                </j:otherwise>
+              </j:choose>
+            </div>
+          </j:when>
+          <j:otherwise>
+            <div id='shutdown-msg'>
+              <j:choose>
+                <j:when test="${app.getQuietDownReason() != null}">
+                  ${app.getQuietDownReason()}
+                </j:when>
+                <j:otherwise>
+                  ${%shutdown}
+                </j:otherwise>
+              </j:choose>
+            </div>
+          </j:otherwise>
+        </j:choose>
+      </j:if>
+      <a id="skip2content" />
+      <x:comment>&#10;start of main content ⇒&#10;</x:comment>
+      <d:invokeBody />
+      <x:comment>&#10;⇐ end of main content&#10;</x:comment>
+    </div>
   </j:if>
 </j:jelly>

--- a/core/src/main/resources/lib/layout/main-panel.jelly
+++ b/core/src/main/resources/lib/layout/main-panel.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
   <j:if test="${mode=='main-panel'}">
     <div id="main-panel" class="app-main-panel
               ${attrs.width eq 'wide' ? 'app-main-panel--wide' : ''}
-              ${(attrs.width eq 'narrow' || attrs.width eq 'default') ? 'app-main-panel--narrow' : ''}">
+              ${attrs.width ne 'wide' ? 'app-main-panel--narrow' : ''}">
       <j:if test="${app.isQuietingDown()}">
         <j:choose>
           <j:when test="${app.isPreparingSafeRestart()}">

--- a/core/src/main/resources/lib/layout/main-panel.jelly
+++ b/core/src/main/resources/lib/layout/main-panel.jelly
@@ -33,8 +33,9 @@ THE SOFTWARE.
 
   <j:if test="${mode=='main-panel'}">
     <div id="main-panel" class="app-main-panel
-              ${attrs.width eq 'wide' ? 'app-main-panel--wide' : ''}
-              ${attrs.width ne 'wide' ? 'app-main-panel--narrow' : ''}">
+              ${layoutType eq 'one-column' ? 'app-main-panel--one-column' : ''}
+              ${(layoutType ne 'one-column' and attrs.width eq 'wide') ? 'app-main-panel--wide' : ''}
+              ${(layoutType ne 'one-column' and attrs.width ne 'wide') ? 'app-main-panel--narrow' : ''}">
       <j:if test="${app.isQuietingDown()}">
         <j:choose>
           <j:when test="${app.isPreparingSafeRestart()}">

--- a/core/src/main/resources/lib/layout/main-panel.jelly
+++ b/core/src/main/resources/lib/layout/main-panel.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
     <div id="main-panel" class="app-main-panel
               ${layoutType eq 'one-column' ? 'app-main-panel--one-column' : ''}
               ${(layoutType ne 'one-column' and attrs.width eq 'wide') ? 'app-main-panel--wide' : ''}
-              ${(layoutType ne 'one-column' and attrs.width ne 'wide') ? 'app-main-panel--narrow' : ''}">
+              ${(layoutType eq 'one-column' or attrs.width ne 'wide') ? 'app-main-panel--narrow' : ''}">
       <j:if test="${app.isQuietingDown()}">
         <j:choose>
           <j:when test="${app.isPreparingSafeRestart()}">

--- a/core/src/main/resources/lib/layout/main-panel.jelly
+++ b/core/src/main/resources/lib/layout/main-panel.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
   <j:if test="${mode=='main-panel'}">
     <div id="main-panel" class="app-main-panel
               ${attrs.width eq 'wide' ? 'app-main-panel--wide' : ''}
-              ${attrs.width eq 'narrow' ? 'app-main-panel--narrow' : ''}">
+              ${(attrs.width eq 'narrow' || attrs.width eq 'default') ? 'app-main-panel--narrow' : ''}">
       <j:if test="${app.isQuietingDown()}">
         <j:choose>
           <j:when test="${app.isPreparingSafeRestart()}">

--- a/core/src/main/resources/lib/layout/settings-subpage.jelly
+++ b/core/src/main/resources/lib/layout/settings-subpage.jelly
@@ -70,7 +70,7 @@ THE SOFTWARE.
       Defaults to false if not set.
     </st:attribute>
     <st:attribute name="width">
-      Optional, sets the width of the page. Available options are 'default' or 'wide'.
+      Optional, sets the width of the page. Available options are 'narrow' or 'wide'.
     </st:attribute>
   </st:documentation>
 
@@ -83,8 +83,7 @@ THE SOFTWARE.
 
   <l:layout title="${pageTitle} - ${manageJenkinsAction.displayName}"
             permission="${attrs.permission}"
-            permissions="${attrs.permissions}"
-            type="${(newManageJenkins or attrs.includeSidepanel) ? 'two-column' : 'one-column'}">
+            permissions="${attrs.permissions}">
 
     <j:if test="${attrs.includeBreadcrumb}">
       <!-- Hacky - this will be improved in subsequent PRs -->
@@ -125,44 +124,40 @@ THE SOFTWARE.
             </j:forEach>
           </l:tasks>
         </l:side-panel>
-        <l:main-panel>
-          <div class="app-settings-container">
-            <div class="app-settings-container__inner ${attrs.width eq 'wide' ? 'app-settings-container__inner--wide' : ''}">
-              <j:if test="${!attrs.containsKey('header')}">
-                <l:app-bar title="${pageTitle}" />
-                <j:if test="${!empty(description)}">
-                  <div class="jenkins-page-description">
-                    ${description}
-                  </div>
-                </j:if>
-              </j:if>
+        <l:main-panel width="${attrs.width ?: 'narrow'}">
+          <j:if test="${!attrs.containsKey('header')}">
+            <l:app-bar title="${pageTitle}" />
+            <j:if test="${!empty(description)}">
+              <div class="jenkins-page-description">
+                ${description}
+              </div>
+            </j:if>
+          </j:if>
 
-              <j:out value="${attrs.header}" />
+          <j:out value="${attrs.header}" />
 
-              <j:choose>
-                <j:when test="${!attrs.noDefer}">
-                  <l:defer>
-                    <l:defer.placeholder>
-                      <j:choose>
-                        <j:when test="${attrs.containsKey('placeholder')}">
-                          <j:out value="${attrs.placeholder}" />
-                        </j:when>
-                        <j:otherwise>
-                          <l:skeleton type="form" />
-                        </j:otherwise>
-                      </j:choose>
-                    </l:defer.placeholder>
-                    <l:defer.children>
-                      <d:invokeBody />
-                    </l:defer.children>
-                  </l:defer>
-                </j:when>
-                <j:otherwise>
+          <j:choose>
+            <j:when test="${!attrs.noDefer}">
+              <l:defer>
+                <l:defer.placeholder>
+                  <j:choose>
+                    <j:when test="${attrs.containsKey('placeholder')}">
+                      <j:out value="${attrs.placeholder}" />
+                    </j:when>
+                    <j:otherwise>
+                      <l:skeleton type="form" />
+                    </j:otherwise>
+                  </j:choose>
+                </l:defer.placeholder>
+                <l:defer.children>
                   <d:invokeBody />
-                </j:otherwise>
-              </j:choose>
-            </div>
-          </div>
+                </l:defer.children>
+              </l:defer>
+            </j:when>
+            <j:otherwise>
+              <d:invokeBody />
+            </j:otherwise>
+          </j:choose>
         </l:main-panel>
       </j:when>
       <j:otherwise>
@@ -170,7 +165,7 @@ THE SOFTWARE.
           <st:include page="sidepanel" />
         </j:if>
 
-        <l:main-panel>
+        <l:main-panel width="${attrs.width ?: 'narrow'}">
           <j:if test="${!attrs.containsKey('header')}">
             <l:app-bar title="${pageTitle}" />
             <j:if test="${!empty(description)}">

--- a/core/src/main/resources/lib/layout/settings-subpage.jelly
+++ b/core/src/main/resources/lib/layout/settings-subpage.jelly
@@ -70,7 +70,7 @@ THE SOFTWARE.
       Defaults to false if not set.
     </st:attribute>
     <st:attribute name="width">
-      Optional, sets the width of the page. Available options are 'narrow' or 'wide'.
+      Optional, sets the width of the page. Available options are 'default', 'narrow', or 'wide'.
     </st:attribute>
   </st:documentation>
 
@@ -124,7 +124,7 @@ THE SOFTWARE.
             </j:forEach>
           </l:tasks>
         </l:side-panel>
-        <l:main-panel width="${attrs.width ?: 'narrow'}">
+        <l:main-panel width="${attrs.width eq 'wide' ? 'wide' : 'narrow'}">
           <j:if test="${!attrs.containsKey('header')}">
             <l:app-bar title="${pageTitle}" />
             <j:if test="${!empty(description)}">
@@ -165,7 +165,7 @@ THE SOFTWARE.
           <st:include page="sidepanel" />
         </j:if>
 
-        <l:main-panel width="${attrs.width ?: 'narrow'}">
+        <l:main-panel width="${attrs.width eq 'wide' ? 'wide' : 'narrow'}">
           <j:if test="${!attrs.containsKey('header')}">
             <l:app-bar title="${pageTitle}" />
             <j:if test="${!empty(description)}">

--- a/core/src/main/resources/lib/layout/side-panel.jelly
+++ b/core/src/main/resources/lib/layout/side-panel.jelly
@@ -26,17 +26,11 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
   <st:documentation>
     Generates a left side content as part of a Jenkins page. Typically known as two-column or left-side +  main-content layouts
-    <st:attribute name="sticky">
-      Make the side panel sticky. Should not be used on pages that include widgets in the sidepanel and when plugins can
-      add their own tasks, so the number of tasks is not fixed.
-    </st:attribute>
-
   </st:documentation>
 
   <j:if test="${mode=='side-panel'}">
-    <div id="side-panel" class="app-page-body__sidebar ${attrs.sticky == 'true' ? 'app-page-body__sidebar--sticky' : ''}">
+    <div id="side-panel" class="app-page-body__sidebar">
       <d:invokeBody />
     </div>
   </j:if>
-
 </j:jelly>

--- a/src/main/js/app.js
+++ b/src/main/js/app.js
@@ -8,6 +8,7 @@ import StopButtonLink from "@/components/stop-button-link";
 import ConfirmationLink from "@/components/confirmation-link";
 import Dialogs from "@/components/dialogs";
 import Defer from "@/components/defer";
+import ScrollRegion from "@/components/scroll-region";
 
 AppBar.init();
 Dropdowns.init();
@@ -19,3 +20,4 @@ Tooltips.init();
 StopButtonLink.init();
 ConfirmationLink.init();
 Dialogs.init();
+ScrollRegion.init();

--- a/src/main/js/components/header/index.js
+++ b/src/main/js/components/header/index.js
@@ -17,44 +17,9 @@ function init() {
     computeOverflow();
   });
 
-  // Fade in the page header on scroll, increasing opacity and intensity of the backdrop blur
-  window.addEventListener("scroll", () => {
-    const navigation = document.querySelector("#page-header");
-    const scrollY = Math.max(0, window.scrollY);
-    navigation.style.setProperty(
-      "--background-opacity",
-      Math.min(70, scrollY) + "%",
-    );
-    navigation.style.setProperty(
-      "--background-blur",
-      Math.min(40, scrollY) + "px",
-    );
-    if (
-      !document.querySelector("#main-panel > .jenkins-search--app-bar") &&
-      !document.querySelector(".app-page-body__sidebar--sticky")
-    ) {
-      const prefersContrast = window.matchMedia(
-        "(prefers-contrast: more)",
-      ).matches;
-      navigation.style.setProperty(
-        "--border-opacity",
-        Math.min(
-          prefersContrast ? 100 : 15,
-          prefersContrast ? scrollY * 3 : scrollY,
-        ) + "%",
-      );
-    }
-  });
-
   window.addEventListener("load", () => {
     // We can't use :has due to HtmlUnit CSS Parser not supporting it, so
     // these are workarounds for that same behaviour
-    if (document.querySelector("#main-panel > .jenkins-app-bar--sticky")) {
-      document
-        .querySelector(".jenkins-header")
-        .classList.add("jenkins-header--has-sticky-app-bar");
-    }
-
     if (!document.querySelector(".jenkins-breadcrumbs__list-item")) {
       document
         .querySelector(".jenkins-header")

--- a/src/main/js/components/scroll-region/index.js
+++ b/src/main/js/components/scroll-region/index.js
@@ -1,0 +1,66 @@
+// The page body scrolls in a nested container rather than the document, so the
+// container has to be focusable for keyboard users to be able to scroll it.
+const CANDIDATES = [".app-page-body__contents", "#page-body"];
+const SCROLL_KEYS = [
+  "End",
+  "Home",
+  "PageUp",
+  "PageDown",
+  "ArrowUp",
+  "ArrowDown",
+  " ",
+];
+
+function scrollsVertically(element) {
+  const overflowY = getComputedStyle(element).overflowY;
+  return overflowY === "auto" || overflowY === "scroll";
+}
+
+let region = null;
+
+function update() {
+  const candidates = CANDIDATES.map((selector) =>
+    document.querySelector(selector),
+  ).filter(Boolean);
+  region = candidates.find(scrollsVertically) || null;
+
+  candidates.forEach((element) => {
+    if (element === region) {
+      element.setAttribute("tabindex", "0");
+      element.setAttribute("role", "region");
+      if (element.dataset.scrollRegionLabel) {
+        element.setAttribute("aria-label", element.dataset.scrollRegionLabel);
+      }
+    } else {
+      element.removeAttribute("tabindex");
+      element.removeAttribute("role");
+      element.removeAttribute("aria-label");
+    }
+  });
+}
+
+function init() {
+  update();
+
+  let lastWidth = window.innerWidth;
+  window.addEventListener("resize", () => {
+    if (window.innerWidth !== lastWidth) {
+      lastWidth = window.innerWidth;
+      update();
+    }
+  });
+
+  // Being focusable is not enough, the browser only scrolls the focused container.
+  // Claiming focus during keydown lets the key's default action apply to the region,
+  // so the first press works without stealing focus on load.
+  document.addEventListener("keydown", (event) => {
+    if (!region || event.target !== document.body) {
+      return;
+    }
+    if (SCROLL_KEYS.includes(event.key)) {
+      region.focus({ preventScroll: true });
+    }
+  });
+}
+
+export default { init };

--- a/src/main/js/components/scroll-region/index.js
+++ b/src/main/js/components/scroll-region/index.js
@@ -13,7 +13,9 @@ const SCROLL_KEYS = [
 
 function scrollsVertically(element) {
   const overflowY = getComputedStyle(element).overflowY;
-  return overflowY === "auto" || overflowY === "scroll";
+  return (
+    overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay"
+  );
 }
 
 let region = null;

--- a/src/main/js/components/scroll-region/index.js
+++ b/src/main/js/components/scroll-region/index.js
@@ -22,6 +22,7 @@ function update() {
   const candidates = CANDIDATES.map((selector) =>
     document.querySelector(selector),
   ).filter(Boolean);
+  const previousRegion = region;
   region = candidates.find(scrollsVertically) || null;
 
   candidates.forEach((element) => {
@@ -37,6 +38,10 @@ function update() {
       element.removeAttribute("aria-label");
     }
   });
+
+  if (previousRegion === document.activeElement && region !== previousRegion) {
+    region?.focus({ preventScroll: true });
+  }
 }
 
 function init() {

--- a/src/main/js/section-to-sidebar-items.js
+++ b/src/main/js/section-to-sidebar-items.js
@@ -1,12 +1,14 @@
-import { createElementFromHtml, toId } from "./util/dom";
+import { createElementFromHtml, getScrollContainer, toId } from "./util/dom";
 
 const HEADER_SELECTOR =
   ".config-table .jenkins-app-bar h2, .config-table > .jenkins-section > .jenkins-section__title, .config-table > section > .jenkins-section > .jenkins-section__title";
 const DEFAULT_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M262.29 192.31a64 64 0 1057.4 57.4 64.13 64.13 0 00-57.4-57.4zM416.39 256a154.34 154.34 0 01-1.53 20.79l45.21 35.46a10.81 10.81 0 012.45 13.75l-42.77 74a10.81 10.81 0 01-13.14 4.59l-44.9-18.08a16.11 16.11 0 00-15.17 1.75A164.48 164.48 0 01325 400.8a15.94 15.94 0 00-8.82 12.14l-6.73 47.89a11.08 11.08 0 01-10.68 9.17h-85.54a11.11 11.11 0 01-10.69-8.87l-6.72-47.82a16.07 16.07 0 00-9-12.22 155.3 155.3 0 01-21.46-12.57 16 16 0 00-15.11-1.71l-44.89 18.07a10.81 10.81 0 01-13.14-4.58l-42.77-74a10.8 10.8 0 012.45-13.75l38.21-30a16.05 16.05 0 006-14.08c-.36-4.17-.58-8.33-.58-12.5s.21-8.27.58-12.35a16 16 0 00-6.07-13.94l-38.19-30A10.81 10.81 0 0149.48 186l42.77-74a10.81 10.81 0 0113.14-4.59l44.9 18.08a16.11 16.11 0 0015.17-1.75A164.48 164.48 0 01187 111.2a15.94 15.94 0 008.82-12.14l6.73-47.89A11.08 11.08 0 01213.23 42h85.54a11.11 11.11 0 0110.69 8.87l6.72 47.82a16.07 16.07 0 009 12.22 155.3 155.3 0 0121.46 12.57 16 16 0 0015.11 1.71l44.89-18.07a10.81 10.81 0 0113.14 4.58l42.77 74a10.8 10.8 0 01-2.45 13.75l-38.21 30a16.05 16.05 0 00-6.05 14.08c.33 4.14.55 8.3.55 12.47z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/></svg>`;
 
+let sectionHeaders = [];
+
 window.addEventListener("load", function () {
   const sidebarItems = document.querySelector("#tasks");
-  const sectionHeaders = document.querySelectorAll(HEADER_SELECTOR);
+  sectionHeaders = Array.from(document.querySelectorAll(HEADER_SELECTOR));
 
   // Create the sidebar items
   sectionHeaders.forEach(function (header, i) {
@@ -34,12 +36,19 @@ window.addEventListener("load", function () {
         item.querySelector(".task-link").dataset.sectionId,
       );
 
-      const sectionTopPosition =
-        headerToScrollTo.getBoundingClientRect().top + window.scrollY - 70;
-      window.scrollTo({
-        top: i === 0 ? 0 : sectionTopPosition,
-        behavior: "smooth",
-      });
+      if (!headerToScrollTo) {
+        return;
+      }
+
+      const container = getScrollContainer(headerToScrollTo);
+      const top =
+        i === 0
+          ? 0
+          : container.scrollTop +
+            topWithinContainer(headerToScrollTo, container) -
+            scrollPaddingTop(container);
+
+      container.scrollTo({ top, behavior: "smooth" });
     });
 
     sidebarItems.insertAdjacentElement("beforeend", item);
@@ -54,33 +63,63 @@ window.addEventListener("load", function () {
       input.parentElement.remove();
     });
 
-  document.addEventListener("scroll", () => onScroll());
+  // Scroll events don't bubble, so capture them to also catch nested containers
+  document.addEventListener(
+    "scroll",
+    (event) => {
+      if (event.target.contains(sectionHeaders[0])) {
+        onScroll();
+      }
+    },
+    true,
+  );
   onScroll();
 });
+
+// Distance between the top of the element and the top of the scrolling container
+function topWithinContainer(element, container) {
+  const top = element.getBoundingClientRect().top;
+
+  if (container === (document.scrollingElement || document.documentElement)) {
+    return top;
+  }
+
+  return top - container.getBoundingClientRect().top;
+}
+
+// scrollTo ignores scroll-padding, so read the offset back from the container
+function scrollPaddingTop(container) {
+  const padding = parseFloat(getComputedStyle(container).scrollPaddingTop);
+
+  return Number.isFinite(padding) ? padding : 0;
+}
 
 /**
  * Change the selected item depending on the user's vertical scroll position
  */
 function onScroll() {
-  const scrollY = Math.max(window.scrollY, 0);
-  const sectionHeaders = document.querySelectorAll(HEADER_SELECTOR);
+  if (sectionHeaders.length === 0) {
+    return;
+  }
 
-  let selectedSection = null;
+  const container = getScrollContainer(sectionHeaders[0]);
+  let selectedSection = sectionHeaders[0];
 
   // Calculate the top and height of each section to know when to switch selected sidebar item
   sectionHeaders.forEach(function (section, i) {
+    if (i === 0) {
+      return;
+    }
+
     const previousSection =
       i === 1
         ? document.querySelectorAll(".jenkins-section")[0]
-        : sectionHeaders[Math.max(i - 1, 0)].parentNode;
-    const viewportEntryOffset =
-      i === 0
-        ? 0
-        : section.parentNode.getBoundingClientRect().top +
-          window.scrollY -
-          previousSection.offsetHeight / 2;
+        : sectionHeaders[i - 1].parentNode;
+    const viewportEntryOffset = (previousSection?.offsetHeight ?? 0) / 2;
 
-    if (scrollY >= viewportEntryOffset) {
+    if (
+      topWithinContainer(section.parentNode, container) <= viewportEntryOffset
+    ) {
       selectedSection = section;
     }
   });
@@ -91,5 +130,5 @@ function onScroll() {
 
   document
     .querySelector(".task-link[data-section-id='" + selectedSection.id + "']")
-    .classList.add("task-link--active");
+    ?.classList.add("task-link--active");
 }

--- a/src/main/js/util/dom.js
+++ b/src/main/js/util/dom.js
@@ -10,3 +10,15 @@ export function toId(string) {
     .map((c) => c.codePointAt(0).toString(16))
     .join("-");
 }
+
+const SCROLLABLE_OVERFLOW = ["auto", "scroll", "overlay"];
+
+// The page body scrolls in a nested container rather than the document
+export function getScrollContainer(element) {
+  for (let node = element.parentElement; node; node = node.parentElement) {
+    if (SCROLLABLE_OVERFLOW.includes(getComputedStyle(node).overflowY)) {
+      return node;
+    }
+  }
+  return document.scrollingElement || document.documentElement;
+}

--- a/src/main/scss/abstracts/_theme.scss
+++ b/src/main/scss/abstracts/_theme.scss
@@ -79,10 +79,14 @@ $semantics: (
   --background: rgb(254 254 254);
 
   // Header
-  --header-background: var(--background);
+  --header-background: color-mix(
+    in sRGB,
+    var(--background),
+    var(--text-color-secondary) 2.5%
+  );
   --header-border: var(--text-color-secondary);
   --header-color: var(--text-color);
-  --header-height: 4.125rem;
+  --header-height: 3.5rem;
 
   // App bar
   --bottom-app-bar-padding: 0.875rem;
@@ -268,7 +272,7 @@ $semantics: (
   --panel-border-color: var(--light-grey);
 
   // Form
-  --section-padding: 1.625rem;
+  --section-padding: 1.25rem;
   --input-color: var(--white);
   --input-border: color-mix(
     in sRGB,
@@ -285,7 +289,7 @@ $semantics: (
   --form-item-max-width--small: min(35vw, 1200px);
 
   @media screen and (max-width: breakpoints.$tablet-breakpoint) {
-    --section-padding: 1.25rem;
+    --section-padding: 1rem;
     --form-item-max-width: 100%;
     --form-item-max-width--medium: 100%;
     --form-item-max-width--small: 100%;
@@ -293,7 +297,7 @@ $semantics: (
 
   --form-label-font-weight: var(--font-bold-weight);
   --form-input-padding: 0.5rem 0.625rem;
-  --form-input-border-radius: 0.625rem;
+  --form-input-border-radius: 0.6875rem;
   --form-input-glow: 0 0 0 0.5rem transparent;
   --form-input-glow--focus: 0 0 0 0.25rem var(--focus-input-glow);
   --pre-background: var(--button-background);

--- a/src/main/scss/base/_core.scss
+++ b/src/main/scss/base/_core.scss
@@ -1,9 +1,8 @@
 html {
-  height: 100%;
   box-sizing: border-box;
   -webkit-tap-highlight-color: transparent;
   color: var(--text-color);
-  scroll-padding-top: calc(var(--header-height) + var(--section-padding));
+  overscroll-behavior: none;
   scrollbar-color: oklch(from var(--text-color-secondary) l c h / 0.35)
     oklch(from var(--text-color-secondary) l c h / 0.05);
 }
@@ -13,7 +12,7 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background-color: var(--background);
+  background-color: var(--header-background);
 }
 
 *,

--- a/src/main/scss/base/_layout-commons.scss
+++ b/src/main/scss/base/_layout-commons.scss
@@ -1,21 +1,103 @@
 @use "../base/breakpoints";
 
-/* -------------------------------------- */
-
 .app-page-body {
-  display: flex;
-  justify-content: flex-start;
-  align-items: stretch;
-  flex: 1 0 auto;
+  position: relative;
+  display: grid;
+  border: var(--jenkins-border);
+  margin-inline: var(--page-inset);
+  height: calc(100vh - var(--header-height) - var(--page-inset));
+  border-radius: var(--form-input-border-radius);
+  overflow: hidden;
+
+  --top: color-mix(in oklch, white 1.5%, var(--card-background));
+  --background: var(--card-background);
+
+  background-color: var(--card-background);
+  background-image: linear-gradient(in oklch, var(--top), var(--background));
+  background-size: 100% 90vh;
+  background-repeat: no-repeat;
+  isolation: isolate;
+
+  &:has(> .app-page-body__sidebar) {
+    grid-template-columns: auto 1fr;
+  }
+
+  @media (width < 740px) {
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+  }
+
+  & > .app-page-body__sidebar {
+    padding: var(--section-padding);
+
+    @media (width >= 740px) {
+      width: 280px;
+      min-height: calc(100vh - var(--header-height) - var(--page-inset));
+    }
+
+    @media (width > breakpoints.$tablet-breakpoint) {
+      width: 320px;
+    }
+  }
+
+  & > .app-page-body__contents {
+    padding: var(--section-padding);
+    padding-bottom: 0;
+  }
+
+  @media (width >= 740px) {
+    &:not(:has(#side-panel .pane, #side-panel .jenkins-card)) {
+      & > .app-page-body__sidebar {
+        overflow-y: auto;
+        border-right: var(--jenkins-border);
+      }
+
+      & > .app-page-body__contents {
+        overflow-y: auto;
+      }
+    }
+  }
+
+  // Remove this when sidepanels no longer contain widgets
+  &:has(#side-panel .pane, #side-panel .jenkins-card) {
+    overflow-y: auto;
+
+    & > .app-page-body__sidebar {
+      padding-right: 0;
+
+      #tasks {
+        margin-bottom: 1rem;
+      }
+
+      .jenkins-card,
+      .pane-frame {
+        margin-inline: -0.5rem;
+      }
+    }
+  }
 }
 
-.app-page-body__sidebar {
-  @media (min-width: breakpoints.$tablet-breakpoint) {
-    &--sticky {
-      position: sticky;
-      top: var(--header-height);
-      align-self: flex-start;
-    }
+.app-main-panel {
+  margin-bottom: var(--section-padding);
+
+  &--narrow {
+    max-width: 900px;
+    margin-inline: auto;
+  }
+
+  &--wide {
+    width: 70vw;
+    max-width: 1700px;
+    margin-inline: auto;
+  }
+}
+
+.app-full-screen-page-body {
+  .app-main-panel {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
   }
 }
 
@@ -23,88 +105,6 @@
   clear: both;
   content: "";
   display: table;
-}
-
-#side-panel {
-  flex-shrink: 0;
-}
-
-#main-panel {
-  padding: 0 var(--section-padding) var(--section-padding)
-    var(--section-padding);
-  display: inline-block;
-  width: 100%;
-}
-
-.app-page-body--one-column {
-  --form-item-max-width: calc(85vw - 4rem);
-
-  @media screen and (width <= 1200px) {
-    --form-item-max-width: 100%;
-  }
-
-  max-width: 85vw;
-
-  #main-panel {
-    width: 100vw;
-  }
-
-  .jenkins-section {
-    max-width: unset;
-  }
-
-  @media (width <= 1200px) {
-    max-width: unset;
-  }
-
-  margin: auto;
-}
-
-body.two-column #main-panel {
-  width: calc(100% - var(--side-panel-width));
-  flex: 1;
-  display: block;
-}
-
-body.full-screen {
-  padding: 0;
-}
-
-body.full-screen #main-panel {
-  padding: 0;
-}
-
-body.two-column #side-panel {
-  width: var(--side-panel-width);
-}
-
-@media (max-width: breakpoints.$tablet-breakpoint) {
-  body.two-column #page-body {
-    flex-wrap: wrap;
-  }
-
-  body.two-column #side-panel {
-    width: 100%;
-    border-right: none;
-  }
-
-  body.two-column #main-panel {
-    margin-left: 0;
-    width: 100%;
-  }
-}
-
-.app-project-status-table {
-  width: 100%;
-  overflow-x: auto;
-}
-
-@media (width >= 1170px) {
-  body.two-column #main-panel {
-    width: calc(
-      100% - calc(var(--side-panel-width) + calc(var(--section-padding) * 2))
-    );
-  }
 }
 
 // Clearfixes extracted from responsive-grid.css as they essential

--- a/src/main/scss/base/_layout-commons.scss
+++ b/src/main/scss/base/_layout-commons.scss
@@ -44,6 +44,9 @@
   & > .app-page-body__contents {
     padding: var(--section-padding);
     padding-bottom: 0;
+
+    // Prevent wide content from inflating the grid track
+    min-width: 0;
   }
 
   @media (width >= 740px) {
@@ -91,6 +94,11 @@
     max-width: 1700px;
     margin-inline: auto;
   }
+}
+
+.app-project-status-table {
+  width: 100%;
+  overflow-x: auto;
 }
 
 .app-full-screen-page-body {

--- a/src/main/scss/base/_layout-commons.scss
+++ b/src/main/scss/base/_layout-commons.scss
@@ -52,22 +52,17 @@
   }
 
   @media (width >= 740px) {
-    &:not(:has(#side-panel .pane, #side-panel .jenkins-card)) {
-      & > .app-page-body__sidebar {
-        overflow-y: auto;
-        border-right: var(--jenkins-border);
-      }
+    & > .app-page-body__sidebar {
+      overflow-y: auto;
+      border-right: var(--jenkins-border);
+    }
 
-      & > .app-page-body__contents {
-        overflow-y: auto;
-      }
+    & > .app-page-body__contents {
+      overflow-y: auto;
     }
   }
 
-  // Remove this when sidepanels no longer contain widgets
   &:has(#side-panel .pane, #side-panel .jenkins-card) {
-    overflow-y: auto;
-
     & > .app-page-body__sidebar {
       padding-right: 0;
 

--- a/src/main/scss/base/_layout-commons.scss
+++ b/src/main/scss/base/_layout-commons.scss
@@ -7,7 +7,7 @@
   margin-inline: var(--page-inset);
   height: calc(100vh - var(--header-height) - var(--page-inset));
   border-radius: var(--form-input-border-radius);
-  overflow: hidden;
+  overflow: clip;
   scroll-padding-top: var(--section-padding);
 
   --top: color-mix(in oklch, white 1.5%, var(--card-background));

--- a/src/main/scss/base/_layout-commons.scss
+++ b/src/main/scss/base/_layout-commons.scss
@@ -105,12 +105,6 @@
   }
 }
 
-#page-body.clear::after {
-  clear: both;
-  content: "";
-  display: table;
-}
-
 // Clearfixes extracted from responsive-grid.css as they essential
 .clearfix::before,
 .clearfix::after,

--- a/src/main/scss/base/_layout-commons.scss
+++ b/src/main/scss/base/_layout-commons.scss
@@ -106,6 +106,32 @@
   }
 }
 
+@media print {
+  .app-page-body {
+    display: block;
+    height: auto;
+    margin-inline: 0;
+    overflow: visible;
+    border: 0;
+    background: none;
+
+    & > .app-page-body__sidebar,
+    & > .app-page-body__contents {
+      overflow: visible;
+    }
+
+    & > .app-page-body__sidebar {
+      width: auto;
+      min-height: auto;
+      border-right: 0;
+    }
+  }
+
+  .app-full-screen-page-body .app-main-panel {
+    min-height: auto;
+  }
+}
+
 // Clearfixes extracted from responsive-grid.css as they essential
 .clearfix::before,
 .clearfix::after,

--- a/src/main/scss/base/_layout-commons.scss
+++ b/src/main/scss/base/_layout-commons.scss
@@ -8,6 +8,7 @@
   height: calc(100vh - var(--header-height) - var(--page-inset));
   border-radius: var(--form-input-border-radius);
   overflow: hidden;
+  scroll-padding-top: var(--section-padding);
 
   --top: color-mix(in oklch, white 1.5%, var(--card-background));
   --background: var(--card-background);
@@ -44,6 +45,7 @@
   & > .app-page-body__contents {
     padding: var(--section-padding);
     padding-bottom: 0;
+    scroll-padding-top: var(--section-padding);
 
     // Prevent wide content from inflating the grid track
     min-width: 0;

--- a/src/main/scss/base/_layout-commons.scss
+++ b/src/main/scss/base/_layout-commons.scss
@@ -81,6 +81,23 @@
 .app-main-panel {
   margin-bottom: var(--section-padding);
 
+  &--one-column {
+    --form-item-max-width: calc(85vw - 4rem);
+
+    max-width: 85vw;
+    margin-inline: auto;
+
+    .jenkins-section {
+      max-width: unset;
+    }
+
+    @media (width <= 1200px) {
+      --form-item-max-width: 100%;
+
+      max-width: none;
+    }
+  }
+
   &--narrow {
     max-width: 900px;
     margin-inline: auto;

--- a/src/main/scss/base/_layout-commons.scss
+++ b/src/main/scss/base/_layout-commons.scss
@@ -90,7 +90,6 @@
   }
 
   &--wide {
-    width: 70vw;
     max-width: 1700px;
     margin-inline: auto;
   }

--- a/src/main/scss/base/_layout-commons.scss
+++ b/src/main/scss/base/_layout-commons.scss
@@ -102,6 +102,7 @@
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    margin-bottom: 0;
   }
 }
 

--- a/src/main/scss/base/_sticky.scss
+++ b/src/main/scss/base/_sticky.scss
@@ -3,13 +3,21 @@
 // clicks.
 // Keep this list in sync with the `position: sticky` rules across the SCSS sources.
 :root[data-disable-sticky="true"] {
-  .jenkins-header,
+  .app-page-body {
+    height: auto !important;
+    overflow: visible !important;
+  }
+
+  .app-page-body > .app-page-body__sidebar,
+  .app-page-body > .app-page-body__contents {
+    overflow-y: visible !important;
+  }
+
   .jenkins-app-bar--sticky,
   .jenkins-bottom-app-bar__shadow,
+  .app-build-bar,
   .bottom-sticker,
-  #bottom-sticker,
-  .app-page-body__sidebar--sticky,
-  .app-plugin-manager__sidebar {
+  #bottom-sticker {
     position: relative !important;
 
     // Reset the sticky offsets too — with relative positioning these would otherwise

--- a/src/main/scss/components/_app-bar.scss
+++ b/src/main/scss/components/_app-bar.scss
@@ -3,7 +3,7 @@
   align-items: center;
   justify-content: space-between;
   margin-bottom: 0.875rem;
-  min-height: 2.875rem;
+  min-height: 2.5rem;
   gap: var(--section-padding);
   flex-wrap: wrap;
 
@@ -68,23 +68,23 @@
 
   &--sticky {
     position: sticky;
-    top: var(--header-height);
+    top: 0;
     z-index: 2;
 
     &::before,
     &::after {
       content: "";
       position: absolute;
-      inset: calc(var(--header-height) * -1)
+      inset: calc(var(--section-padding) * -1)
         calc(var(--section-padding) * -1) -0.875rem;
       z-index: -1;
       pointer-events: none;
     }
 
     &::before {
-      background: var(--background);
+      background: var(--top);
       mask-image: linear-gradient(black 70%, transparent);
-      opacity: 0.55;
+      opacity: 0.6;
     }
 
     &::after {
@@ -106,7 +106,8 @@
   h1,
   h2 {
     margin: 0;
-    font-size: 1.3125rem;
+    font-size: 1.1875rem;
+    font-weight: 550;
   }
 
   &__subtitle {

--- a/src/main/scss/components/_breadcrumbs.scss
+++ b/src/main/scss/components/_breadcrumbs.scss
@@ -9,6 +9,7 @@
 
   &__list {
     display: flex;
+    margin: 0;
 
     & > * {
       z-index: 1;

--- a/src/main/scss/components/_page-footer.scss
+++ b/src/main/scss/components/_page-footer.scss
@@ -4,6 +4,7 @@
   width: 100%;
   clear: both;
   font-size: var(--font-size-sm);
+  display: none;
 }
 
 .page-footer .container-fluid {

--- a/src/main/scss/components/_page-footer.scss
+++ b/src/main/scss/components/_page-footer.scss
@@ -5,6 +5,11 @@
   clear: both;
   font-size: var(--font-size-sm);
   display: none;
+
+  @media print {
+    // Override jenkins-mobile-hide when the printable page is narrower than 768px.
+    display: block !important;
+  }
 }
 
 .page-footer .container-fluid {

--- a/src/main/scss/components/_page-header.scss
+++ b/src/main/scss/components/_page-header.scss
@@ -1,13 +1,6 @@
 @use "../abstracts/mixins";
 
 .jenkins-header {
-  --background-opacity: 0%;
-  --background-blur: 0;
-  --border-opacity: 0%;
-
-  position: sticky;
-  top: 0;
-  z-index: 999;
   display: flex;
   align-items: center;
   gap: var(--section-padding);
@@ -15,26 +8,6 @@
   line-height: var(--line-height-base);
   min-height: var(--header-height);
   color: var(--header-color);
-
-  &::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    backdrop-filter: blur(var(--background-blur));
-    background: color-mix(
-      in sRGB,
-      var(--header-background) var(--background-opacity),
-      transparent
-    );
-    border-bottom: var(--jenkins-border-width) solid
-      color-mix(
-        in sRGB,
-        var(--header-border) var(--border-opacity),
-        transparent
-      );
-    background-clip: padding-box;
-    z-index: -1;
-  }
 
   .app-jenkins-logo {
     @include mixins.item($border: false);
@@ -79,7 +52,7 @@
     }
 
     #jenkins-head-icon {
-      width: 1.625rem;
+      width: 1.5rem;
     }
   }
 
@@ -90,11 +63,6 @@
 
     // For customizable-header-plugin
     color: inherit !important;
-
-    svg {
-      width: 1.25rem;
-      height: 1.25rem;
-    }
 
     img {
       width: 1.625rem;
@@ -121,7 +89,7 @@
   &__main {
     display: grid;
     grid-template-columns: 1fr auto;
-    padding-left: var(--section-padding);
+    padding-left: calc(var(--section-padding) + var(--page-inset));
     width: 100%;
   }
 
@@ -135,14 +103,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.5rem;
-    padding-right: var(--section-padding);
-  }
-
-  &--has-sticky-app-bar {
-    &::before {
-      mask-image: linear-gradient(black 50%, transparent);
-    }
+    gap: 0.25rem;
+    padding-right: calc(var(--section-padding) + var(--page-inset));
   }
 
   &--no-breadcrumbs {

--- a/src/main/scss/components/_side-panel-tasks.scss
+++ b/src/main/scss/components/_side-panel-tasks.scss
@@ -1,19 +1,14 @@
 @use "../abstracts/mixins";
 @use "../base/breakpoints";
 
-$background-outset: 0.5rem;
+$inset: 0.6875rem;
 
 #tasks,
 .tasks,
 .subtasks {
   display: flex;
   flex-direction: column;
-  margin: 0 var(--section-padding) var(--section-padding) var(--section-padding);
   gap: 0.125rem;
-
-  @media (min-width: breakpoints.$tablet-breakpoint) {
-    margin-right: calc($background-outset);
-  }
 }
 
 .subtasks {
@@ -27,12 +22,11 @@ $background-outset: 0.5rem;
 
 #side-panel {
   .jenkins-app-bar {
-    margin-left: var(--section-padding);
-    margin-right: var(--section-padding);
+    margin-inline: $inset;
   }
 
   & > #tasks > .jenkins-search-container {
-    margin: 0 0 1rem #{-$background-outset};
+    margin: 0 0 1rem;
 
     .jenkins-search__icon {
       width: 2.625rem;
@@ -45,10 +39,6 @@ $background-outset: 0.5rem;
   }
 }
 
-#tasks .task {
-  margin: 0 0 0 calc($background-outset * -1);
-}
-
 #tasks,
 .tasks {
   .task .task-link {
@@ -57,7 +47,7 @@ $background-outset: 0.5rem;
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    padding: 0.5rem 0.6875rem;
+    padding: 0.5rem $inset;
     gap: 0.625rem;
     width: 100%;
     font-size: var(--font-size-sm);
@@ -115,7 +105,7 @@ $background-outset: 0.5rem;
   font-size: var(--font-size-sm);
   color: var(--text-color-secondary);
   font-weight: var(--font-bold-weight);
-  margin: 1rem 0 0.375rem;
+  margin: 1rem 0 0.375rem $inset;
 
   &:first-of-type {
     margin-top: 0.375rem;

--- a/src/main/scss/components/_side-panel-widgets.scss
+++ b/src/main/scss/components/_side-panel-widgets.scss
@@ -8,10 +8,6 @@
   overflow: hidden;
 }
 
-#side-panel .pane-frame {
-  margin-left: 10px;
-}
-
 #side-panel .pane-header,
 .app-build-content .pane-header {
   font-size: var(--font-size-sm);

--- a/src/main/scss/components/_table.scss
+++ b/src/main/scss/components/_table.scss
@@ -312,3 +312,8 @@
     }
   }
 }
+
+.jenkins-table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+}

--- a/src/main/scss/pages/_build.scss
+++ b/src/main/scss/pages/_build.scss
@@ -12,7 +12,6 @@
 
 .app-build__grid {
   gap: calc(var(--section-padding) / 2);
-  margin-bottom: calc(var(--section-padding) * -0.5);
 
   & > * {
     height: 350px;
@@ -139,101 +138,66 @@
   }
 }
 
-body:has(.app-build-bar),
-body:has(.app-settings-container) {
-  --top: color-mix(in sRGB, var(--text-color-secondary) 4%, var(--background));
-  --bottom: color-mix(
-    in sRGB,
-    var(--text-color-secondary) 2%,
-    var(--background)
-  );
+@keyframes app-build-bar-border-on-scroll {
+  from {
+    border-bottom-color: color-mix(
+      in sRGB,
+      var(--jenkins-border-color),
+      transparent
+    );
+  }
 
-  background: linear-gradient(var(--top), var(--bottom));
-  background-attachment: fixed;
-}
-
-.app-settings-container {
-  --background: var(--card-background);
-  --top: color-mix(
-    in sRGB,
-    var(--text-color-secondary) 2%,
-    var(--card-background)
-  );
-
-  position: relative;
-  background-color: var(--card-background);
-  background-image: linear-gradient(var(--top), var(--card-background));
-  background-size: 100% 90vh;
-  background-repeat: no-repeat;
-  border: var(--jenkins-border);
-  border-radius: var(--form-input-border-radius);
-  z-index: 0;
-  min-height: calc(100vh - var(--header-height) - var(--section-padding));
-
-  &__inner {
-    max-width: 900px;
-    margin: auto;
-    padding: var(--section-padding);
-    display: flex;
-    flex-direction: column;
-
-    &--wide {
-      width: 70vw;
-      max-width: 1700px;
-    }
-
-    // TODO - this can be moved to app-bar.scss when Manage Jenkins flag is removed
-    .jenkins-app-bar--sticky {
-      padding: var(--section-padding) 0 !important;
-      margin: -1rem 0 0.5rem !important;
-
-      &::before,
-      &::after {
-        inset: 0 !important;
-      }
-
-      &::before {
-        background: color-mix(
-          in sRGB,
-          var(--text-color-secondary) 2%,
-          var(--card-background)
-        ) !important;
-        mask-image: linear-gradient(black 60%, transparent) !important;
-        opacity: 0.75 !important;
-      }
-
-      &::after {
-        left: calc(var(--section-padding) * -1) !important;
-        right: calc(var(--section-padding) * -1) !important;
-        mask-image: linear-gradient(black 65%, transparent) !important;
-      }
-    }
+  to {
+    border-bottom-color: var(--jenkins-border-color);
   }
 }
 
 .app-build-bar {
-  position: relative;
+  --app-build-bar-border-color: color-mix(
+    in sRGB,
+    var(--jenkins-border-color),
+    transparent
+  );
+
+  position: sticky;
+  top: 0;
   display: grid;
   grid-template-columns: 1fr auto 1fr;
-  align-items: start;
+  align-items: center;
   gap: 0.5rem 1.5rem;
-  min-height: 2.875rem;
-  margin-top: -5px;
-  padding-bottom: 0.75rem;
+  min-height: var(--header-height);
+  background-color: color-mix(in oklch, transparent 25%, var(--top));
+  padding-inline: var(--section-padding);
   z-index: 102;
-
-  @media (width <= 1200px) {
-    display: flex;
-    flex-direction: column;
-  }
+  border-bottom: var(--jenkins-border-width) solid
+    var(--app-build-bar-border-color);
+  margin-left: calc(var(--section-padding) * -1);
+  margin-right: calc(var(--section-padding) * -1);
 
   &::before {
     content: "";
     position: absolute;
-    inset: -1000px calc(var(--section-padding) * -1) 0;
-    background-color: var(--background);
-    border-bottom: var(--jenkins-border-width) solid var(--card-border-color);
+    inset: 0;
     z-index: -1;
+    pointer-events: none;
+    backdrop-filter: blur(15px);
+  }
+
+  @supports (animation-timeline: scroll()) {
+    animation-name: app-build-bar-border-on-scroll;
+    animation-duration: 1s;
+    animation-fill-mode: both;
+    animation-timing-function: linear;
+    animation-timeline: scroll(nearest block);
+    animation-range: 0 var(--header-height);
+  }
+
+  @media (width < 740px) {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+    padding-block: var(--section-padding);
   }
 
   .app-build-bar__content {
@@ -247,6 +211,7 @@ body:has(.app-settings-container) {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    margin-block: 0.5rem;
   }
 
   .app-build-bar__controls {
@@ -254,7 +219,7 @@ body:has(.app-settings-container) {
     align-items: center;
     justify-content: end;
     flex: 1;
-    gap: 0.75rem;
+    gap: 0.5rem;
 
     @media (width <= 600px) {
       justify-content: stretch;
@@ -278,12 +243,14 @@ body:has(.app-settings-container) {
     svg {
       width: 2rem;
       height: 2rem;
+      flex-shrink: 0;
     }
   }
 
   h1 {
     margin-bottom: 0;
-    font-size: 1.25rem;
+    font-size: 1.1875rem;
+    font-weight: 550;
   }
 
   .jenkins-button {
@@ -323,6 +290,10 @@ body:has(.app-settings-container) {
   .app-build__navigation-next:hover {
     translate: 0.0625rem 0;
   }
+}
+
+.app-page-body__contents:has(.app-build-bar) {
+  padding-top: 0;
 }
 
 .app-build-content {

--- a/src/main/scss/pages/_job.scss
+++ b/src/main/scss/pages/_job.scss
@@ -1,11 +1,5 @@
 @use "../abstracts/mixins";
 
-#side-panel {
-  #buildHistoryPage {
-    margin: 10px 0 10px 10px;
-  }
-}
-
 #buildHistoryPage {
   .jenkins-search {
     margin-inline: -0.25rem;

--- a/src/main/scss/pages/_plugin-manager.scss
+++ b/src/main/scss/pages/_plugin-manager.scss
@@ -104,13 +104,3 @@
     border-radius: 0.25em;
   }
 }
-
-.app-plugin-manager__sidebar {
-  position: sticky;
-  top: calc(40px + 1.6rem);
-
-  h1 {
-    margin-top: 1rem !important;
-    margin-bottom: 0.1rem !important;
-  }
-}

--- a/src/test/js/scroll-region.test.js
+++ b/src/test/js/scroll-region.test.js
@@ -71,6 +71,15 @@ describe("scroll-region", () => {
     expect(pageBody.getAttribute("role")).toBe("region");
   });
 
+  it("treats overlay overflow as a scrollable region", async () => {
+    const { contents, pageBody } = render({ contentsOverflow: "overlay" });
+
+    await load();
+
+    expect(contents.getAttribute("tabindex")).toBe("0");
+    expect(pageBody.hasAttribute("tabindex")).toBe(false);
+  });
+
   it("updates the active region when a responsive width change moves scrolling", async () => {
     const originalWidth = window.innerWidth;
     const { contents, pageBody } = render();

--- a/src/test/js/scroll-region.test.js
+++ b/src/test/js/scroll-region.test.js
@@ -71,13 +71,54 @@ describe("scroll-region", () => {
     expect(pageBody.getAttribute("role")).toBe("region");
   });
 
-  it("focuses the scroll region when the first scroll key is pressed on the page", async () => {
+  it("updates the active region when a responsive width change moves scrolling", async () => {
+    const originalWidth = window.innerWidth;
+    const { contents, pageBody } = render();
+    const { resize } = await load();
+
+    contents.style.overflowY = "visible";
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: originalWidth + 1,
+    });
+
+    try {
+      resize();
+
+      expect(contents.hasAttribute("tabindex")).toBe(false);
+      expect(pageBody.getAttribute("tabindex")).toBe("0");
+      expect(pageBody.getAttribute("role")).toBe("region");
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: originalWidth,
+      });
+    }
+  });
+
+  it("focuses the scroll region for every supported scroll key", async () => {
     const { contents } = render();
     const focus = vi.spyOn(contents, "focus");
     const { keydown } = await load();
 
-    keydown({ target: document.body, key: "PageDown" });
+    ["End", "Home", "PageUp", "PageDown", "ArrowUp", "ArrowDown", " "].forEach(
+      (key) => keydown({ target: document.body, key }),
+    );
 
-    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+    expect(focus).toHaveBeenCalledTimes(7);
+    expect(focus).toHaveBeenLastCalledWith({ preventScroll: true });
+  });
+
+  it("does not steal focus for unrelated keys or from an interactive control", async () => {
+    const { contents } = render();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    const focus = vi.spyOn(contents, "focus");
+    const { keydown } = await load();
+
+    keydown({ target: document.body, key: "Enter" });
+    keydown({ target: input, key: "PageDown" });
+
+    expect(focus).not.toHaveBeenCalled();
   });
 });

--- a/src/test/js/scroll-region.test.js
+++ b/src/test/js/scroll-region.test.js
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function render({ contentsOverflow = "auto", pageBodyOverflow = "auto" } = {}) {
+  document.body.innerHTML = `
+    <main
+      class="app-page-body__contents"
+      data-scroll-region-label="Main content"
+      style="overflow-y: ${contentsOverflow}"
+    ></main>
+    <div id="page-body" style="overflow-y: ${pageBodyOverflow}"></div>
+  `;
+
+  return {
+    contents: document.querySelector(".app-page-body__contents"),
+    pageBody: document.querySelector("#page-body"),
+  };
+}
+
+async function load() {
+  const listeners = {};
+  const documentListener = vi
+    .spyOn(document, "addEventListener")
+    .mockImplementation((type, handler) => {
+      if (type === "keydown") {
+        listeners.keydown = handler;
+      }
+    });
+  const windowListener = vi
+    .spyOn(window, "addEventListener")
+    .mockImplementation((type, handler) => {
+      if (type === "resize") {
+        listeners.resize = handler;
+      }
+    });
+
+  vi.resetModules();
+  const { default: scrollRegion } =
+    await import("../../main/js/components/scroll-region/index.js");
+  scrollRegion.init();
+
+  documentListener.mockRestore();
+  windowListener.mockRestore();
+  return listeners;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+});
+
+describe("scroll-region", () => {
+  it("makes the main content region focusable before the legacy page body", async () => {
+    const { contents, pageBody } = render();
+
+    await load();
+
+    expect(contents.getAttribute("tabindex")).toBe("0");
+    expect(contents.getAttribute("role")).toBe("region");
+    expect(contents.getAttribute("aria-label")).toBe("Main content");
+    expect(pageBody.hasAttribute("tabindex")).toBe(false);
+    expect(pageBody.hasAttribute("role")).toBe(false);
+  });
+
+  it("falls back to the legacy page body when the contents do not scroll", async () => {
+    const { contents, pageBody } = render({ contentsOverflow: "visible" });
+
+    await load();
+
+    expect(contents.hasAttribute("tabindex")).toBe(false);
+    expect(pageBody.getAttribute("tabindex")).toBe("0");
+    expect(pageBody.getAttribute("role")).toBe("region");
+  });
+
+  it("focuses the scroll region when the first scroll key is pressed on the page", async () => {
+    const { contents } = render();
+    const focus = vi.spyOn(contents, "focus");
+    const { keydown } = await load();
+
+    keydown({ target: document.body, key: "PageDown" });
+
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+});

--- a/src/test/js/scroll-region.test.js
+++ b/src/test/js/scroll-region.test.js
@@ -96,6 +96,30 @@ describe("scroll-region", () => {
     }
   });
 
+  it("moves focus when a responsive width change selects a new region", async () => {
+    const originalWidth = window.innerWidth;
+    const { contents, pageBody } = render();
+    const { resize } = await load();
+
+    contents.focus();
+    contents.style.overflowY = "visible";
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: originalWidth + 1,
+    });
+
+    try {
+      resize();
+
+      expect(document.activeElement).toBe(pageBody);
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: originalWidth,
+      });
+    }
+  });
+
   it("focuses the scroll region for every supported scroll key", async () => {
     const { contents } = render();
     const focus = vi.spyOn(contents, "focus");

--- a/src/test/js/section-to-sidebar-items.test.js
+++ b/src/test/js/section-to-sidebar-items.test.js
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The page body scrolls in a nested container rather than the document, so these
+ * tests assert which element is scrolled rather than how far the page moved.
+ * jsdom has no layout, so element rectangles are stubbed.
+ */
+const CONTAINER_TOP = 100;
+
+function render() {
+  document.body.innerHTML = `
+    <div id="tasks"></div>
+    <div id="page-body">
+      <div class="contents">
+        <div class="config-table">
+          <div class="jenkins-app-bar"><h2>General</h2></div>
+          <section class="jenkins-section">
+            <div class="jenkins-section__title">Triggers</div>
+          </section>
+          <section class="jenkins-section">
+            <div class="jenkins-section__title">Advanced</div>
+          </section>
+        </div>
+      </div>
+    </div>
+  `;
+
+  return document.querySelector(".contents");
+}
+
+function stubTop(element, top) {
+  element.getBoundingClientRect = () => ({
+    top,
+    bottom: top,
+    left: 0,
+    right: 0,
+    width: 0,
+    height: 0,
+    x: 0,
+    y: top,
+  });
+}
+
+function heading(text) {
+  return Array.from(
+    document.querySelectorAll(".jenkins-section__title, .jenkins-app-bar h2"),
+  ).find((element) => element.textContent.trim() === text);
+}
+
+function click(text) {
+  Array.from(document.querySelectorAll(".task-link"))
+    .find((button) => button.textContent.trim() === text)
+    .click();
+}
+
+function activeItem() {
+  const active = document.querySelector(".task-link--active");
+
+  return active ? active.textContent.trim() : null;
+}
+
+/**
+ * Loads the module, capturing the listeners it registers instead of letting them
+ * accumulate on the shared window and document between tests.
+ */
+async function load() {
+  const captured = {};
+  const onWindow = vi
+    .spyOn(window, "addEventListener")
+    .mockImplementation((type, handler) => {
+      if (type === "load") {
+        captured.load = handler;
+      }
+    });
+  const onDocument = vi
+    .spyOn(document, "addEventListener")
+    .mockImplementation((type, handler, options) => {
+      if (type === "scroll") {
+        captured.scroll = handler;
+        captured.scrollOptions = options;
+      }
+    });
+
+  vi.resetModules();
+  await import("../../main/js/section-to-sidebar-items.js");
+  captured.load();
+
+  onWindow.mockRestore();
+  onDocument.mockRestore();
+
+  return captured;
+}
+
+describe("section-to-sidebar-items", () => {
+  let contents;
+
+  beforeEach(() => {
+    contents = render();
+    contents.style.overflowY = "auto";
+    stubTop(contents, CONTAINER_TOP);
+    contents.scrollTo = vi.fn();
+    window.scrollTo = vi.fn();
+  });
+
+  it("builds a sidebar item for every section heading", async () => {
+    await load();
+
+    expect(
+      Array.from(document.querySelectorAll(".task-link-text")).map((item) =>
+        item.textContent.trim(),
+      ),
+    ).toEqual(["General", "Triggers", "Advanced"]);
+  });
+
+  it("scrolls the container the sections live in, never the window", async () => {
+    stubTop(heading("Triggers"), 400);
+    contents.scrollTop = 50;
+    await load();
+
+    click("Triggers");
+
+    // 50 already scrolled + (400 - 100) to the heading
+    expect(contents.scrollTo).toHaveBeenCalledWith({
+      top: 350,
+      behavior: "smooth",
+    });
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("subtracts the container's scroll-padding-top", async () => {
+    contents.style.scrollPaddingTop = "20px";
+    stubTop(heading("Triggers"), 400);
+    contents.scrollTop = 50;
+    await load();
+
+    click("Triggers");
+
+    expect(contents.scrollTo).toHaveBeenCalledWith({
+      top: 330,
+      behavior: "smooth",
+    });
+  });
+
+  it("returns to the top for the first item", async () => {
+    contents.scrollTop = 900;
+    await load();
+
+    click("General");
+
+    expect(contents.scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      behavior: "smooth",
+    });
+  });
+
+  it("falls back to the document when no ancestor scrolls", async () => {
+    contents.style.overflowY = "visible";
+    const scroller = document.scrollingElement || document.documentElement;
+    scroller.scrollTo = vi.fn();
+    scroller.scrollTop = 40;
+    stubTop(heading("Triggers"), 400);
+    await load();
+
+    click("Triggers");
+
+    expect(scroller.scrollTo).toHaveBeenCalledWith({
+      top: 440,
+      behavior: "smooth",
+    });
+    expect(contents.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("listens for scroll in the capture phase, as it does not bubble", async () => {
+    const captured = await load();
+
+    expect(captured.scrollOptions).toBe(true);
+  });
+
+  it("moves the selected item as the container scrolls", async () => {
+    stubTop(heading("Triggers").parentNode, 500);
+    stubTop(heading("Advanced").parentNode, 900);
+    const captured = await load();
+    expect(activeItem()).toBe("General");
+
+    // the container has scrolled, so Triggers is now above the fold
+    stubTop(heading("Triggers").parentNode, 50);
+    captured.scroll({ target: contents });
+
+    expect(activeItem()).toBe("Triggers");
+  });
+
+  it("ignores scrolling of elements the sections do not live in", async () => {
+    stubTop(heading("Triggers").parentNode, 500);
+    stubTop(heading("Advanced").parentNode, 900);
+    const captured = await load();
+    const unrelated = document.createElement("textarea");
+    document.body.appendChild(unrelated);
+
+    stubTop(heading("Triggers").parentNode, 50);
+    captured.scroll({ target: unrelated });
+
+    expect(activeItem()).toBe("General");
+  });
+});

--- a/test/src/test/java/lib/layout/LayoutTest.java
+++ b/test/src/test/java/lib/layout/LayoutTest.java
@@ -24,13 +24,20 @@
 
 package lib.layout;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import hudson.model.InvisibleAction;
+import hudson.model.RootAction;
 import org.htmlunit.html.DomElement;
 import org.htmlunit.html.HtmlLink;
+import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
@@ -65,6 +72,21 @@ class LayoutTest {
     void fullScreen() throws Exception {
         // Example page using <l:layout type="full-screen">:
         r.createWebClient().goTo("setupWizard/proxy-configuration");
+    }
+
+    @Test
+    void mainPanelDefaultWidthIsNarrow() throws Exception {
+        HtmlPage page = r.createWebClient().goTo("mainPanelDefaultWidth");
+
+        assertThat(page.getElementById("main-panel").getAttribute("class"), containsString("app-main-panel--narrow"));
+    }
+
+    @TestExtension("mainPanelDefaultWidthIsNarrow")
+    public static class MainPanelDefaultWidth extends InvisibleAction implements RootAction {
+        @Override
+        public String getUrlName() {
+            return "mainPanelDefaultWidth";
+        }
     }
 
 }

--- a/test/src/test/resources/lib/layout/LayoutTest/MainPanelDefaultWidth/index.jelly
+++ b/test/src/test/resources/lib/layout/LayoutTest/MainPanelDefaultWidth/index.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+  <l:layout title="Main panel default width" type="one-column">
+    <l:main-panel width="default">
+      Main panel content
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2088,6 +2088,14 @@ function AutoScroller(scrollContainer) {
     return null;
   }
 
+  function isViewportScroller(scrollDiv) {
+    return (
+      scrollDiv === document.body ||
+      scrollDiv === document.documentElement ||
+      scrollDiv === document.scrollingElement
+    );
+  }
+
   return {
     bottomThreshold: 25,
     scrollContainer: scrollContainer,
@@ -2111,14 +2119,13 @@ function AutoScroller(scrollContainer) {
 
       // when used with the BODY tag, the height needs to be the viewport height, instead of
       // the element height.
-      //var height = ((scrollDiv.style.pixelHeight) ? scrollDiv.style.pixelHeight : scrollDiv.offsetHeight);
-      var height = getViewportHeight();
-      var scrollPos = Math.max(
-        scrollDiv.scrollTop,
-        document.documentElement.scrollTop,
-      );
-      var diff = currentHeight - scrollPos - height;
-      // window.alert("currentHeight=" + currentHeight + ",scrollTop=" + scrollDiv.scrollTop + ",height=" + height);
+      const height = isViewportScroller(scrollDiv)
+        ? getViewportHeight()
+        : scrollDiv.clientHeight;
+      const scrollPos = isViewportScroller(scrollDiv)
+        ? Math.max(scrollDiv.scrollTop, document.documentElement.scrollTop)
+        : scrollDiv.scrollTop;
+      const diff = currentHeight - scrollPos - height;
 
       return diff < this.bottomThreshold;
     },
@@ -2127,7 +2134,7 @@ function AutoScroller(scrollContainer) {
       var scrollDiv = this.scrollContainer;
       var currentHeight = this.getCurrentHeight();
 
-      if (scrollDiv === document.body) {
+      if (isViewportScroller(scrollDiv)) {
         window.scrollTo({
           top: currentHeight,
         });

--- a/war/src/main/webapp/scripts/hudson-behavior.js
+++ b/war/src/main/webapp/scripts/hudson-behavior.js
@@ -2100,8 +2100,15 @@ function AutoScroller(scrollContainer) {
     bottomThreshold: 25,
     scrollContainer: scrollContainer,
 
+    // May be a function so that a container which varies with the layout can be re-resolved.
+    resolveScrollContainer: function () {
+      return typeof this.scrollContainer === "function"
+        ? this.scrollContainer()
+        : this.scrollContainer;
+    },
+
     getCurrentHeight: function () {
-      var scrollDiv = this.scrollContainer;
+      var scrollDiv = this.resolveScrollContainer();
 
       if (scrollDiv.scrollHeight > 0) {
         return scrollDiv.scrollHeight;
@@ -2114,7 +2121,7 @@ function AutoScroller(scrollContainer) {
 
     // return true if we are in the "stick to bottom" mode
     isSticking: function () {
-      var scrollDiv = this.scrollContainer;
+      var scrollDiv = this.resolveScrollContainer();
       var currentHeight = this.getCurrentHeight();
 
       // when used with the BODY tag, the height needs to be the viewport height, instead of
@@ -2131,7 +2138,7 @@ function AutoScroller(scrollContainer) {
     },
 
     scrollToBottom: function () {
-      var scrollDiv = this.scrollContainer;
+      var scrollDiv = this.resolveScrollContainer();
       var currentHeight = this.getCurrentHeight();
 
       if (isViewportScroller(scrollDiv)) {


### PR DESCRIPTION
Part of #27375

This PR reintroduces the experimental page layout reverted in #27265 and addresses the reported scrolling regressions.

This combined branch includes the original layout work from #26863 together with fixes for Dashboard table scrolling (#27200), keyboard-operable scroll regions (#27243), progressive Console Output scrolling (#27242), job configuration section navigation (#27270), and Nodes-page extension compatibility (#27187).

## Purpose

Restore independently scrollable page content and side panels while preserving responsive behavior, sticky build bars, accessible keyboard scrolling, table containment, and progressive log following.

The imported commits retain their original authorship. This PR distinguishes imported work from the additional integration work completed on this branch.

## Before

- Pages with legacy side-panel widgets made `.app-page-body` the vertical scroll owner, so sidebar and main content moved together.
- Dashboard and Nodes tables could overflow their intended table regions on narrower viewports.
- Nested scroll regions were not keyboard-operable until clicked.
- Progressive Console Output did not reliably follow new output.
- Job configuration section links could scroll the document rather than the nested configuration region.
- Some pages displayed unnecessary or duplicate scrollbars.

## After

- Sidebar and content regions independently own vertical scrolling at desktop widths, including pages with legacy sidebar widgets.
- Dashboard and Nodes tables scroll horizontally inside their own table wrappers.
- The active scroll region can receive keyboard focus on the first supported scrolling key.
- Progressive Console Output follows newly appended output.
- Job configuration section links scroll the selected nested content section into view.
- The outer page frame no longer becomes an unnecessary fallback scroll owner.
- Plugin Manager Installed, Available, and Updates tables now use the existing table wrapper, so horizontal overflow is contained within each table rather than widening the page-content scroll region.
- One-column pages use the layout type to preserve the legacy 85vw desktop constraint and responsive behavior below the desktop breakpoint.
- Scroll-region keyboard support also recognizes `overflow-y: overlay`, matching the existing scroll-container detection behavior.
- Printing preserves the complete page content, including later Console Output pages.

## Change provenance and attribution

This branch reintroduces the layout baseline from #26863 and integrates the existing proposed fixes for Dashboard scrolling (#27200), keyboard-operable scroll regions (#27243), progressive Console Output scrolling (#27242), job configuration navigation (#27270), and Nodes-page extension compatibility (#27187).

The imported commits retain their original authorship and `cherry picked from` references. Additional integration commits on this branch correct widget-sidebar scroll ownership and add focused keyboard scroll-region coverage.

### Testing done

Automated checks:

- `corepack yarn lint` — passed.
- `corepack yarn test` — passed: 3 files, 20 tests.
- `mvn -pl test "-Dtest=lib.layout.LayoutTest" test` — passed: 3 tests, 0 failures.
- `mvn -am -pl war,bom -Pquick-build install` — passed: all 7 reactor modules.
- The quick-build profile intentionally skips Java test compilation and execution.
- Started the rebuilt WAR with a dedicated Jenkins home on port 8083; it returned HTTP 200.

Manual regression checks completed:

- Confirmed independent Dashboard sidebar and content scrolling.
- Confirmed Dashboard and Nodes horizontal scrolling stays inside each table wrapper.
- Confirmed live Console Output follows newly appended output.
- Confirmed job configuration section links scroll the nested content region.
- Confirmed rightmost scrollbar dragging works and unnecessary double scrollbars are absent.
- Confirmed keyboard scrolling and focus behavior with `End`, `Home`, `PageDown`, arrow keys, `Tab`, and `Shift+Tab`.
- Rechecked Dashboard, Nodes, job overview, job Configure, Console Output, and Plugin Manager after a hard refresh.

Additional focused regression checks:

- At 768px, Plugin Manager Installed and Available tables keep horizontal overflow inside their table wrapper; sidebar navigation, search fields, and page controls remain stationary. Updates correctly shows “No updates available” when no update rows exist.
- One-column pages preserve the 85vw desktop constraint and use the available responsive width at 768px without page-level horizontal overflow.
- `overflow-y: overlay` is covered by a focused frontend regression test.
- Print preview was checked through page 6 and included the final Console Output content.
- `corepack yarn test` passed: 3 files, 20 tests. Focused lint/formatting checks and `mvn -am -pl war,bom -Pquick-build install` also passed.


### Screenshots (UI changes only)

#### Before

Attach here:

1. `before-dashboard-at-start.png`
<img width="1918" height="1060" alt="before-dashboard-at-start" src="https://github.com/user-attachments/assets/4ec90539-a0c9-42c9-b914-125e3b806aef" />

2. `before-dashboard-at-last.png`
<img width="1919" height="1095" alt="before-dashboard-at-last" src="https://github.com/user-attachments/assets/7501af58-22e9-48ee-85e2-3ff1afe8c986" />

3. `nodes-table-extending-outside-first.png`
<img width="1215" height="1069" alt="nodes-table-extending-outside-first" src="https://github.com/user-attachments/assets/470a7e03-17c3-41a0-8eb6-d39c1996579c" />

4. `nodes-table-extending-outside-last.png`
<img width="1194" height="1048" alt="nodes-table-extending-outside-last" src="https://github.com/user-attachments/assets/960a2ff2-e7fb-4473-90f3-dec32accc589" />

5. `plugin-manager-available-before-768.png`
At 768px, the Plugin Manager table widens the page-content region instead of providing a table-local horizontal scrollbar.
<img width="1232" height="1081" alt="Screenshot 2026-09-11 234540" src="https://github.com/user-attachments/assets/3c641b20-0233-412f-bb3d-16d7a366797e" />


#### After

Attach here:

1. `Dashboardsidebar-independently-scrolling.png`
<img width="1919" height="1073" alt="Dashboardsidebar-independently-scrolling" src="https://github.com/user-attachments/assets/39e8b681-5749-470f-b89a-1607a576ab38" />

2. `Nodes table's in-wrapper horizontal scrollbar at 768 px.png`
<img width="1219" height="1081" alt="Nodes table&#39;s in-wrapper horizontal scrollbar at 768 px" src="https://github.com/user-attachments/assets/91145adc-17af-424c-b482-f053e224fc12" />

3. `console-output-logs-live.mp4`

https://github.com/user-attachments/assets/ec1baae3-40c7-4ce6-af13-03a3fb474409

4. `Job configuration section navigation at its selected section.mp4`

https://github.com/user-attachments/assets/d4adf468-9dbb-4771-a96a-64860e2cc1f4

 5. `plugin-manager-available-table-scroll-768.png`
 
<img width="1218" height="1077" alt="Screenshot 2026-09-12 013019" src="https://github.com/user-attachments/assets/fa4388e4-b718-42e1-8fef-d97cfca23980" />
Installed Plugins was manually verified with the same table-local horizontal scrolling behavior.

### Proposed changelog entries

- Restore independent scrolling for Jenkins pages with widget sidebars.

### Proposed changelog category

/label regression-fix,web-ui

### Proposed upgrade guidelines

N/A

### Submitter checklist

- [x] The issue, if it exists, is well-described.
- [x] The changelog entries and upgrade guidelines are appropriate for the audience affected by the change and are in the imperative mood.
- [x] There is automated testing or an explanation as to why this change has no tests.
- [x] New public classes, fields, and methods are annotated with `@Restricted` or have `@since TODO` Javadocs, as appropriate. No public API is added.
- [x] New deprecations are annotated with `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")`, if applicable. No deprecation is added.
- [x] UI changes do not introduce regressions when enforcing the current default rules of the Content Security Policy Plugin. No new or substantially changed JavaScript is inline or uses `eval`.
- [x] For dependency updates, there are links to external changelogs and, if possible, full differentials. This change has no dependency updates.
- [x] For new APIs and extension points, there is a link to at least one consumer. This change adds no new APIs or extension points.
- [x] Final screenshots / recording are attached before submission.

### Desired reviewers

@MarkEWaite

Before the changes are marked as `ready-for-merge`:

### Maintainer checklist

- [ ] There are at least two (2) approvals for the pull request and no outstanding requests for change.
- [ ] Conversations in the pull request are over, or it is explicit that a reviewer is not blocking the change.
- [ ] Changelog entries in the pull request title and/or **Proposed changelog entries** are accurate, human-readable, and in the imperative mood.
- [ ] Proper changelog labels are set so that the changelog can be generated automatically.
- [ ] If the change needs additional upgrade steps from users, the `upgrade-guide-needed` label is set and there is a **Proposed upgrade guidelines** section in the pull request title.
- [ ] If it would make sense to backport the change to LTS, be a _Bug_ or _Improvement_, and either the issue or pull request must be labeled as `lts-candidate` to be considered.